### PR TITLE
chore(build): include typings in the build

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,6 +1,7 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
+  declaration: true,
   entries: [
     'src/index',
     'src/node'


### PR DESCRIPTION
The build of the recent (0.3.0) release did not include type declarations. This PR is attempting to fix this.

Resolves #11 