### PR TITLE
Issue-13: Make parse optional

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -53,11 +53,9 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
       if (opts.params) {
         request = withQuery(request, opts.params)
       }
-      if (opts.body && opts.body.toString() === '[object Object]' && payloadMethods.includes(opts.method?.toLowerCase() || '')) {
-        opts.body = opts.parse ? JSON.stringify(opts.body) : opts.body
-        if (opts.parse) {
-          setHeader(opts, 'content-type', 'application/json')
-        }
+      if (opts.body && opts.body.toString() === '[object Object]' && payloadMethods.includes(opts.method?.toLowerCase() || '') && opts.parse) {
+        opts.body = JSON.stringify(opts.body)
+        setHeader(opts, 'content-type', 'application/json')
       }
     }
     const response: FetchResponse<any> = await fetch(request, opts as RequestInit)

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -15,6 +15,7 @@ export interface FetchOptions extends Omit<RequestInit, 'body'> {
   baseURL?: string
   body?: RequestInit['body'] | Record<string, any>
   params?: SearchParams
+  parse?: boolean
   response?: boolean
 }
 
@@ -53,8 +54,10 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
         request = withQuery(request, opts.params)
       }
       if (opts.body && opts.body.toString() === '[object Object]' && payloadMethods.includes(opts.method?.toLowerCase() || '')) {
-        opts.body = JSON.stringify(opts.body)
-        setHeader(opts, 'content-type', 'application/json')
+        opts.body = opts.parse ? JSON.stringify(opts.body) : opts.body
+        if (opts.parse) {
+          setHeader(opts, 'content-type', 'application/json')
+        }
       }
     }
     const response: FetchResponse<any> = await fetch(request, opts as RequestInit)
@@ -67,7 +70,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
   }
 
   const $fetch = function (request, opts) {
-    return raw(request, opts).then(r => r.data)
+    return raw(request, { parse: true, ...opts }).then(r => r.data)
   } as $Fetch
 
   $fetch.raw = raw


### PR DESCRIPTION
Closes: #13 

**Description**
This PR aims to make parsing optional.

- It creates a new object to pass through as options, setting parse to true and then spreading consumer options. This will overwrite the parse set to true, if parse is passed through.
- If parse is set, then it parses the JSON body and automatically adds headers. If parse is set to false, then body is maintained and headers are not changed.
- Parse is added to the FetchOptions type as an optional boolean.