### PR TITLE
Issue 13: Allow for custom parse

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -34,9 +34,7 @@ const getParser: GetParser = (parse) => {
     return undefined
   }
 
-  return typeof parse === 'boolean'
-    ? destr
-    : parse
+  return parse === true ? destr : parse
 }
 
 export function setHeader (options: FetchOptions, _key: string, value: string) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -15,7 +15,7 @@ export interface FetchOptions extends Omit<RequestInit, 'body'> {
   baseURL?: string
   body?: RequestInit['body'] | Record<string, any>
   params?: SearchParams
-  parse?: 'destr' | 'JSON.parse' | boolean
+  parse?: (text: string) => any
   response?: boolean
 }
 
@@ -60,7 +60,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
     }
     const response: FetchResponse<any> = await fetch(request, opts as RequestInit)
     const text = await response.text()
-    response.data = destr(text)
+    response.data = opts?.parse ? opts.parse(text) : text
     if (!response.ok) {
       throw createFetchError(request, response)
     }
@@ -68,7 +68,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
   }
 
   const $fetch = function (request, opts) {
-    return raw(request, { parse: true, ...opts }).then(r => r.data)
+    return raw(request, { parse: destr, ...opts }).then(r => r.data)
   } as $Fetch
 
   $fetch.raw = raw

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -15,6 +15,7 @@ export interface FetchOptions extends Omit<RequestInit, 'body'> {
   baseURL?: string
   body?: RequestInit['body'] | Record<string, any>
   params?: SearchParams
+  parse?: 'destr' | 'JSON.parse' | boolean
   response?: boolean
 }
 
@@ -67,7 +68,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
   }
 
   const $fetch = function (request, opts) {
-    return raw(request, opts).then(r => r.data)
+    return raw(request, { parse: true, ...opts }).then(r => r.data)
   } as $Fetch
 
   $fetch.raw = raw


### PR DESCRIPTION
**Closes #13**

### Description

This PR allows for automatic response parsing to be disabled. This can be accomplished through passing `{ parse: false }` into fetch options.

This PR also allows for custom parsing functions to be used. For example, `JSON.parse` can be used by passing `{ parse: JSON.parse }` into fetch options.

Parsing still defaults to `destr`. 