### PR TITLE
fix: check for `globalThis` before fallback to shims

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,12 @@ import { createFetch } from './base'
 
 export * from './base'
 
-// ref: https://mathiasbynens.be/notes/globalthis
-const getGlobal = () => {
+// ref: https://github.com/tc39/proposal-global
+const getGlobal = function () {
   if (typeof globalThis !== 'undefined') { return globalThis }
   if (typeof self !== 'undefined') { return self }
   if (typeof window !== 'undefined') { return window }
   if (typeof global !== 'undefined') { return global }
-  if (typeof this !== 'undefined') { return this }
   throw new Error('unable to locate global object')
 }
 


### PR DESCRIPTION
I just updated the getGlobal function to get the best result! Not a significant change at all 😄 