### PR TITLE
fix: remove baseurl append on retry

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -54,6 +54,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
       if (retries > 0) {
         return $fetchRaw(request, {
           ...opts,
+          baseURL: '',
           retry: retries - 1
         })
       }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,5 @@
 import destr from 'destr'
-import { joinURL, withQuery } from 'ufo'
+import { withBase, withQuery } from 'ufo'
 import type { Fetch, RequestInfo, RequestInit, Response } from './types'
 import { createFetchError } from './error'
 
@@ -54,7 +54,6 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
       if (retries > 0) {
         return $fetchRaw(request, {
           ...opts,
-          baseURL: '',
           retry: retries - 1
         })
       }
@@ -69,7 +68,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
   const $fetchRaw: $Fetch['raw'] = async function $fetchRaw (request, opts = {}) {
     if (typeof request === 'string') {
       if (opts.baseURL) {
-        request = joinURL(opts.baseURL, request)
+        request = withBase(request, opts.baseURL)
       }
       if (opts.params) {
         request = withQuery(request, opts.params)

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -61,4 +61,9 @@ describe('ohmyfetch', () => {
     expect(err.response?.data).to.deep.eq(err.data)
     expect(err.request).to.equal(getURL('404'))
   })
+
+  it('baseURL with retry', async () => {
+    const err = await $fetch('', { baseURL: getURL('404'), retry: 3 }).catch(err => err)
+    expect(err.request).to.equal(getURL('404'))
+  })
 })


### PR DESCRIPTION
Removes further baseURL appends when retrying.

closes #24 