### PR TITLE
fix: add check for using `Error.captureStackTrace`

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -61,7 +61,10 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
 
     // Throw normalized error
     const err = createFetchError(request, error, response)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, $fetchRaw)
+    // Only available on V8 based runtimes (https://v8.dev/docs/stack-trace-api)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(err, $fetchRaw)
+    }
     throw err
   }
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -61,7 +61,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
 
     // Throw normalized error
     const err = createFetchError(request, error, response)
-    Error.captureStackTrace(err, $fetchRaw)
+    if (Error.captureStackTrace) Error.captureStackTrace(err, $fetchRaw)
     throw err
   }
 


### PR DESCRIPTION
This fixes #26.

A single line is changed, to wrap the call to `Error.captureStackTrace(err, $fetchRaw)` in a existence-check, as other libraries do to maintain compatibility with non-Chromium browsers.