### PR TITLE
fix: add accept header when using json payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ await $fetch('/movie?lang=en', { parseResponse: txt => txt })
 
 ## ✔️ JSON Body
 
-`$fetch` automatically stringifies request body (if an object is passed) and adds JSON `Content-Type` headers (for `put`, `patch` and `post` requests).
+`$fetch` automatically stringifies request body (if an object is passed) and adds JSON `Content-Type` and `Accept` headers (for `put`, `patch` and `post` requests).
 
 ```js
 const { users } = await $fetch('/api/users', { method: 'POST', body: { some: 'json' } })

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -80,6 +80,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
       if (opts.body && typeof opts.body === 'object' && hasPayload) {
         opts.body = JSON.stringify(opts.body)
         setHeader(opts, 'content-type', 'application/json')
+        setHeader(opts, 'accept', 'application/json')
       }
     }
     const response: FetchResponse<any> = await fetch(request, opts as RequestInit).catch(error => onError(request, opts, error, undefined))

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -54,6 +54,7 @@ describe('ohmyfetch', () => {
     for (const sentHeaders of headerFetches) {
       const { headers } = await $fetch(getURL('post'), { method: 'POST', body: { num: 42 }, headers: sentHeaders })
       expect(headers).to.include({ 'content-type': 'application/json' })
+      expect(headers).to.include({ accept: 'application/json' })
     }
   })
 


### PR DESCRIPTION
Some API (like https://github.com/login/oauth/access_token) needs `POST` and expect an `Accept: application/json` header to return json.

See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github

When no using the `Accept` headers, it sends back:
```
error=bad_verification_code&error_description=The+code+passed+is+incorrect+or+expired.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-oauth-app-access-token-request-errors%2F%23bad-verification-code
```