### PR TITLE
feat: return blob if `content-type` isn't text, svg, xml or json

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ By setting `FETCH_KEEP_ALIVE` environment variable to `true`, A http/https agent
 
 ## ✔️ Parsing Response
 
-`$fetch` Smartly parses JSON and native values using [destr](https://github.com/unjs/destr) and fallback to text if it fails to parse.
+`$fetch` will smartly parse JSON and native values using [destr](https://github.com/unjs/destr) (and fall back to text if it fails to parse).
 
 ```js
 const { users } = await $fetch('/api/users')
 ```
 
-You can optionally provde a different parser than destr.
+For binary content types, `$fetch` will instead return a `Blob` object.
+
+You can optionally provde a different parser than destr, or specify `blob` or `json` to force parsing the body with the respective `FetchResponse` method.
 
 ```js
 // Use JSON.parse
@@ -71,6 +73,9 @@ await $fetch('/movie?lang=en', { parseResponse: JSON.parse })
 
 // Return text as is
 await $fetch('/movie?lang=en', { parseResponse: txt => txt })
+
+// Get a blob
+await $fetch('/movie?lang=en', { parseResponse: 'blob' })
 ```
 
 ## ✔️ JSON Body

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const { users } = await $fetch('/api/users')
 
 For binary content types, `$fetch` will instead return a `Blob` object.
 
-You can optionally provde a different parser than destr, or specify `blob` or `json` to force parsing the body with the respective `FetchResponse` method.
+You can optionally provde a different parser than destr, or specify `blob`, `arrayBuffer` or `text` to force parsing the body with the respective `FetchResponse` method.
 
 ```js
 // Use JSON.parse

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ By setting `FETCH_KEEP_ALIVE` environment variable to `true`, A http/https agent
 
 ## ✔️ Parsing Response
 
-`$fetch` will smartly parse JSON and native values using [destr](https://github.com/unjs/destr) (and fall back to text if it fails to parse).
+`$fetch` will smartly parse JSON and native values using [destr](https://github.com/unjs/destr), falling back to text if it fails to parse.
 
 ```js
 const { users } = await $fetch('/api/users')
@@ -74,8 +74,8 @@ await $fetch('/movie?lang=en', { parseResponse: JSON.parse })
 // Return text as is
 await $fetch('/movie?lang=en', { parseResponse: txt => txt })
 
-// Get a blob
-await $fetch('/movie?lang=en', { parseResponse: 'blob' })
+// Get the blob version of the response
+await $fetch('/api/generate-image', { responseType: 'blob' })
 ```
 
 ## ✔️ JSON Body

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/node-fetch": "^3.0.3",
     "chai": "latest",
     "eslint": "latest",
+    "fetch-blob": "^3.1.3",
     "formdata-polyfill": "^4.0.10",
     "h3": "latest",
     "jiti": "latest",

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -10,12 +10,21 @@ export type FetchRequest = RequestInfo
 
 export interface SearchParams { [key: string]: any }
 
-export interface FetchOptions extends Omit<RequestInit, 'body'> {
+interface ResponseMap {
+  blob: Blob
+  text: string
+  arrayBuffer: ArrayBuffer
+}
+
+type ResponseType = keyof ResponseMap | 'json'
+type MappedType<R extends ResponseType, JsonType = any> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType
+
+export interface FetchOptions<R extends ResponseType = ResponseType> extends Omit<RequestInit, 'body'> {
   baseURL?: string
   body?: RequestInit['body'] | Record<string, any>
   params?: SearchParams
   parseResponse?: (responseText: string) => any
-  responseType?: 'blob' | 'json' | 'text' | 'arrayBuffer'
+  responseType?: R
   response?: boolean
   retry?: number | false
 }
@@ -23,8 +32,8 @@ export interface FetchOptions extends Omit<RequestInit, 'body'> {
 export interface FetchResponse<T> extends Response { data?: T }
 
 export interface $Fetch {
-  <T = any>(request: FetchRequest, opts?: FetchOptions): Promise<T>
-  raw<T = any>(request: FetchRequest, opts?: FetchOptions): Promise<FetchResponse<T>>
+  <T = any, R extends ResponseType = 'json'>(request: FetchRequest, opts?: FetchOptions<R>): Promise<MappedType<R, T>>
+  raw<T = any, R extends ResponseType = 'json'>(request: FetchRequest, opts?: FetchOptions<R>): Promise<FetchResponse<MappedType<R, T>>>
 }
 
 export function setHeader (options: FetchOptions, _key: string, value: string) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,7 +2,7 @@ import destr from 'destr'
 import { withBase, withQuery } from 'ufo'
 import type { Fetch, RequestInfo, RequestInit, Response } from './types'
 import { createFetchError } from './error'
-import { isPayloadMethod, isJSONSerializable, detectContentMethod } from './utils'
+import { isPayloadMethod, isJSONSerializable, detectResponseType } from './utils'
 
 export interface CreateFetchOptions { fetch: Fetch }
 
@@ -16,7 +16,7 @@ interface ResponseMap {
   arrayBuffer: ArrayBuffer
 }
 
-type ResponseType = keyof ResponseMap | 'json'
+export type ResponseType = keyof ResponseMap | 'json'
 type MappedType<R extends ResponseType, JsonType = any> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType
 
 export interface FetchOptions<R extends ResponseType = ResponseType> extends Omit<RequestInit, 'body'> {
@@ -94,7 +94,7 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
     }
     const response: FetchResponse<any> = await fetch(request, opts as RequestInit).catch(error => onError(request, opts, error, undefined))
 
-    const responseType = opts.parseResponse ? 'json' : opts.responseType || detectContentMethod(response.headers.get('content-type') || '')
+    const responseType = opts.parseResponse ? 'json' : opts.responseType || detectResponseType(response.headers.get('content-type') || '')
 
     // We override the `.json()` method to parse the body more securely with `destr`
     if (responseType === 'json') {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -85,15 +85,15 @@ export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
     }
     const response: FetchResponse<any> = await fetch(request, opts as RequestInit).catch(error => onError(request, opts, error, undefined))
 
-    const responseType = opts.parseResponse ? 'text' : opts.responseType || detectContentMethod(response.headers.get('content-type') || '')
+    const responseType = opts.parseResponse ? 'json' : opts.responseType || detectContentMethod(response.headers.get('content-type') || '')
 
-    const data = await response[responseType]()
-
-    if (responseType === 'text') {
+    // We override the `.json()` method to parse the body more securely with `destr`
+    if (responseType === 'json') {
+      const data = await response.text()
       const parseFn = opts.parseResponse || destr
       response.data = parseFn(data)
     } else {
-      response.data = data
+      response.data = await response[responseType]()
     }
 
     return response.ok ? response : onError(request, opts, undefined, response)

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,22 +2,13 @@ import destr from 'destr'
 import { withBase, withQuery } from 'ufo'
 import type { Fetch, RequestInfo, RequestInit, Response } from './types'
 import { createFetchError } from './error'
-import { isPayloadMethod, isJSONSerializable, detectResponseType } from './utils'
+import { isPayloadMethod, isJSONSerializable, detectResponseType, ResponseType, MappedType } from './utils'
 
 export interface CreateFetchOptions { fetch: Fetch }
 
 export type FetchRequest = RequestInfo
 
 export interface SearchParams { [key: string]: any }
-
-interface ResponseMap {
-  blob: Blob
-  text: string
-  arrayBuffer: ArrayBuffer
-}
-
-export type ResponseType = keyof ResponseMap | 'json'
-type MappedType<R extends ResponseType, JsonType = any> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType
 
 export interface FetchOptions<R extends ResponseType = ResponseType> extends Omit<RequestInit, 'body'> {
   baseURL?: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,21 +20,27 @@ export function isJSONSerializable (val: any) {
   return val.constructor?.name === 'Object' || typeof val.toJSON === 'function'
 }
 
-// This provides reasonable defaults for the correct parser based on Content-Type header
-export function detectContentMethod (contentType = ''): 'text' | 'blob' {
-  // Value might look like: `application/json; charset=utf-8`
-  switch (true) {
-    case !contentType:
-    case contentType.startsWith('text/'):
-    case contentType.startsWith('image/svg'):
-    case contentType.startsWith('application/xml'):
-    case contentType.startsWith('application/xhtml'):
-    case contentType.startsWith('application/html'):
-    case contentType.startsWith('application/json'):
-    case contentType.startsWith('application/ld+json'):
-      return 'text'
+const textTypes = new Set([
+  'image/svg',
+  'application/xml',
+  'application/xhtml',
+  'application/html',
+  'application/json',
+  'application/ld+json'
+])
 
-    default:
-      return 'blob'
+// This provides reasonable defaults for the correct parser based on Content-Type header
+export function detectContentMethod (_contentType = ''): 'text' | 'blob' | 'json' | 'arrayBuffer' {
+  if (!_contentType) {
+    return 'text'
   }
+
+  // Value might look like: `application/json; charset=utf-8`
+  const contentType = _contentType.split(';').shift()!
+
+  if (textTypes.has(contentType) || contentType.startsWith('text/')) {
+    return 'text'
+  }
+
+  return 'blob'
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,19 +24,23 @@ const textTypes = new Set([
   'image/svg',
   'application/xml',
   'application/xhtml',
-  'application/html',
-  'application/json',
-  'application/ld+json'
+  'application/html'
 ])
 
-// This provides reasonable defaults for the correct parser based on Content-Type header
+const jsonTypes = new Set(['application/json', 'application/ld+json'])
+
+// This provides reasonable defaults for the correct parser based on Content-Type header.
 export function detectContentMethod (_contentType = ''): 'text' | 'blob' | 'json' | 'arrayBuffer' {
   if (!_contentType) {
-    return 'text'
+    return 'json'
   }
 
   // Value might look like: `application/json; charset=utf-8`
   const contentType = _contentType.split(';').shift()!
+
+  if (jsonTypes.has(contentType)) {
+    return 'json'
+  }
 
   if (textTypes.has(contentType) || contentType.startsWith('text/')) {
     return 'text'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { ResponseType } from '.'
+
 const payloadMethods = new Set(Object.freeze(['PATCH', 'POST', 'PUT', 'DELETE']))
 export function isPayloadMethod (method: string = 'GET') {
   return payloadMethods.has(method.toUpperCase())
@@ -30,7 +32,7 @@ const textTypes = new Set([
 const jsonTypes = new Set(['application/json', 'application/ld+json'])
 
 // This provides reasonable defaults for the correct parser based on Content-Type header.
-export function detectContentMethod (_contentType = ''): 'text' | 'blob' | 'json' | 'arrayBuffer' {
+export function detectResponseType (_contentType = ''): ResponseType {
   if (!_contentType) {
     return 'json'
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,22 @@ export function isJSONSerializable (val: any) {
   }
   return val.constructor?.name === 'Object' || typeof val.toJSON === 'function'
 }
+
+// This provides reasonable defaults for the correct parser based on Content-Type header
+export function detectContentMethod (contentType = ''): 'text' | 'blob' {
+  // Value might look like: `application/json; charset=utf-8`
+  switch (true) {
+    case !contentType:
+    case contentType.startsWith('text/'):
+    case contentType.startsWith('image/svg'):
+    case contentType.startsWith('application/xml'):
+    case contentType.startsWith('application/xhtml'):
+    case contentType.startsWith('application/html'):
+    case contentType.startsWith('application/json'):
+    case contentType.startsWith('application/ld+json'):
+      return 'text'
+
+    default:
+      return 'blob'
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import type { ResponseType } from '.'
-
 const payloadMethods = new Set(Object.freeze(['PATCH', 'POST', 'PUT', 'DELETE']))
 export function isPayloadMethod (method: string = 'GET') {
   return payloadMethods.has(method.toUpperCase())
@@ -30,6 +28,15 @@ const textTypes = new Set([
 ])
 
 const jsonTypes = new Set(['application/json', 'application/ld+json'])
+
+interface ResponseMap {
+  blob: Blob
+  text: string
+  arrayBuffer: ArrayBuffer
+}
+
+export type ResponseType = keyof ResponseMap | 'json'
+export type MappedType<R extends ResponseType, JsonType = any> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType
 
 // This provides reasonable defaults for the correct parser based on Content-Type header.
 export function detectResponseType (_contentType = ''): ResponseType {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -40,9 +40,10 @@ describe('ohmyfetch', () => {
   })
 
   it('allows specifying FetchResponse method', async () => {
-    expect(await $fetch(getURL('params?test=true'), { parseResponse: 'json' })).to.deep.equal({ test: 'true' })
-    expect(await $fetch(getURL('params?test=true'), { parseResponse: 'blob' })).to.be.instanceOf(Blob)
-    expect(await $fetch(getURL('params?test=true'), { parseResponse: 'text' })).to.deep.equal({ test: 'true' })
+    expect(await $fetch(getURL('params?test=true'), { responseType: 'json' })).to.deep.equal({ test: 'true' })
+    expect(await $fetch(getURL('params?test=true'), { responseType: 'blob' })).to.be.instanceOf(Blob)
+    expect(await $fetch(getURL('params?test=true'), { responseType: 'text' })).to.deep.equal({ test: 'true' })
+    expect(await $fetch(getURL('params?test=true'), { responseType: 'arrayBuffer' })).to.be.instanceOf(ArrayBuffer)
   })
 
   it('returns a blob for binary content-type', async () => {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -42,7 +42,7 @@ describe('ohmyfetch', () => {
   it('allows specifying FetchResponse method', async () => {
     expect(await $fetch(getURL('params?test=true'), { responseType: 'json' })).to.deep.equal({ test: 'true' })
     expect(await $fetch(getURL('params?test=true'), { responseType: 'blob' })).to.be.instanceOf(Blob)
-    expect(await $fetch(getURL('params?test=true'), { responseType: 'text' })).to.deep.equal({ test: 'true' })
+    expect(await $fetch(getURL('params?test=true'), { responseType: 'text' })).to.equal('{"test":"true"}')
     expect(await $fetch(getURL('params?test=true'), { responseType: 'arrayBuffer' })).to.be.instanceOf(ArrayBuffer)
   })
 

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -4,6 +4,7 @@ import { createApp, useBody } from 'h3'
 import { expect } from 'chai'
 import { Headers } from 'node-fetch'
 import { $fetch } from 'ohmyfetch'
+import { Blob } from 'fetch-blob'
 import { FormData } from 'formdata-polyfill/esm.min.js'
 
 describe('ohmyfetch', () => {
@@ -16,6 +17,10 @@ describe('ohmyfetch', () => {
       .use('/params', req => (getQuery(req.url || '')))
       .use('/url', req => req.url)
       .use('/post', async req => ({ body: await useBody(req), headers: req.headers }))
+      .use('/binary', (_req, res) => {
+        res.setHeader('Content-Type', 'application/octet-stream')
+        return new Blob(['binary'])
+      })
     listener = await listen(app)
   })
 
@@ -32,6 +37,16 @@ describe('ohmyfetch', () => {
     const parser = (r) => { called++; return 'C' + r }
     expect(await $fetch(getURL('ok'), { parseResponse: parser })).to.equal('Cok')
     expect(called).to.equal(1)
+  })
+
+  it('allows specifying FetchResponse method', async () => {
+    expect(await $fetch(getURL('params?test=true'), { parseResponse: 'json' })).to.deep.equal({ test: 'true' })
+    expect(await $fetch(getURL('params?test=true'), { parseResponse: 'blob' })).to.be.instanceOf(Blob)
+    expect(await $fetch(getURL('params?test=true'), { parseResponse: 'text' })).to.deep.equal({ test: 'true' })
+  })
+
+  it('returns a blob for binary content-type', async () => {
+    expect(await $fetch(getURL('binary'))).to.be.instanceOf(Blob)
   })
 
   it('baseURL', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,7 +1795,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fetch-blob@^3.1.2:
+fetch-blob@^3.1.2, fetch-blob@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.3.tgz#a7dca4855e39d3e3c5a1da62d4ee335c37d26012"
   integrity sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==


### PR DESCRIPTION
resolves  #38

For binary content types, `$fetch` will instead return a `Blob` object.

You can optionally specify `blob`, `arrayBuffer` or `text` to force parsing the body with the respective `FetchResponse` method.

```js
// Use JSON.parse
await $fetch('/movie?lang=en', { parseResponse: JSON.parse })

// Return text as is
await $fetch('/movie?lang=en', { parseResponse: txt => txt })

// Get the blob version of the response
await $fetch('/api/generate-image', { responseType: 'blob' })
```

## Typing
```ts
$fetch('api') // Promise<any>
$fetch<boolean>('api') // Promise<boolean>
$fetch<boolean>('api', { responseType: 'text' }) // Type '"text"' is not assignable to type '"json" | undefined'.ts(2322)
$fetch('api', { responseType: 'json' }) // Promise<any>
$fetch<boolean>('api', { responseType: 'json' }) // Promise<boolean>
$fetch('api', { responseType: 'text' }) // Promise<string>
$fetch('api', { responseType: 'arrayBuffer' }) // Promise<ArrayBuffer>
$fetch('api', { responseType: 'blob' }) // Promise<Blob>
```