### PR TITLE
feat: allow user overrides of `content-type` and `accept`

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -29,8 +29,6 @@ export interface $Fetch {
 
 export function normalizeHeaders (_opts: FetchOptions): Pick<Headers, 'get' | 'set' | 'has'> {
   const opts = (_opts as FetchOptions & { _headers: Pick<Headers, 'get' | 'set' | 'has'> })
-
-  // @ts-ignore
   if (opts._headers) { return opts._headers }
 
   opts.headers = opts.headers || {}

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -40,7 +40,7 @@ export function normalizeHeaders (options: FetchOptions): Pick<Headers, 'get' | 
     return {
       get: (_key: string) => {
         const key = _key.toLowerCase()
-        return findHeader(_key)?.[1] || null
+        return findHeader(key)?.[1] || null
       },
       set: (_key: string, value: string) => {
         const key = _key.toLowerCase()

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -30,18 +30,13 @@ export interface $Fetch {
 export function normalizeHeaders (options: FetchOptions): Pick<Headers, 'get' | 'set'> {
   options.headers = options.headers || {}
 
-  if ('set' in options.headers) {
-    return options.headers as Pick<Headers, 'get' | 'set'>
-  }
+  if ('set' in options.headers) { return options.headers as Pick<Headers, 'get' | 'set'> }
 
   if (Array.isArray(options.headers)) {
     const headers = options.headers
     const findHeader = (key: string) => headers.find(([header]) => header.toLowerCase() === key)
     return {
-      get: (_key) => {
-        const key = _key.toLowerCase()
-        return findHeader(key)?.[1] || null
-      },
+      get: key => findHeader(key.toLowerCase())?.[1] || null,
       set: (_key, value) => {
         const key = _key.toLowerCase()
         const existingHeader = findHeader(key)
@@ -57,9 +52,8 @@ export function normalizeHeaders (options: FetchOptions): Pick<Headers, 'get' | 
   const headers = options.headers
   const findHeaderKey = (key: string) => Object.keys(headers).find(header => header.toLowerCase() === key)
   return {
-    get: (_key) => {
-      const key = _key.toLowerCase()
-      const existingHeader = findHeaderKey(key)
+    get: (key) => {
+      const existingHeader = findHeaderKey(key.toLowerCase())
       return existingHeader ? headers[existingHeader] : null
     },
     set: (_key, value) => {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -38,11 +38,11 @@ export function normalizeHeaders (options: FetchOptions): Pick<Headers, 'get' | 
     const headers = options.headers
     const findHeader = (key: string) => headers.find(([header]) => header.toLowerCase() === key)
     return {
-      get: (_key: string) => {
+      get: (_key) => {
         const key = _key.toLowerCase()
         return findHeader(key)?.[1] || null
       },
-      set: (_key: string, value: string) => {
+      set: (_key, value) => {
         const key = _key.toLowerCase()
         const existingHeader = findHeader(key)
         if (existingHeader) {
@@ -57,12 +57,12 @@ export function normalizeHeaders (options: FetchOptions): Pick<Headers, 'get' | 
   const headers = options.headers
   const findHeaderKey = (key: string) => Object.keys(headers).find(header => header.toLowerCase() === key)
   return {
-    get: (_key: string) => {
+    get: (_key) => {
       const key = _key.toLowerCase()
       const existingHeader = findHeaderKey(key)
       return existingHeader ? headers[existingHeader] : null
     },
-    set: (_key: string, value: string) => {
+    set: (_key, value) => {
       const key = _key.toLowerCase()
       const existingHeader = findHeaderKey(key)
       headers[existingHeader || key] = value

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -70,15 +70,9 @@ export function normalizeHeaders (options: FetchOptions): Pick<Headers, 'get' | 
   }
 }
 
-export const getHeader = (options: FetchOptions, _key: string) => {
-  const headers = normalizeHeaders(options)
-  return headers.get(_key)
-}
+export const getHeader = (options: FetchOptions, key: string) => normalizeHeaders(options).get(key)
 
-export const setHeader = (options: FetchOptions, _key: string, value: string) => {
-  const headers = normalizeHeaders(options)
-  headers.set(_key, value)
-}
+export const setHeader = (options: FetchOptions, key: string, value: string) => normalizeHeaders(options).set(key, value)
 
 export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
   function onError (request: FetchRequest, opts: FetchOptions, error?: Error, response?: FetchResponse<any>): Promise<FetchResponse<any>> {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -52,10 +52,6 @@ export function normalizeHeaders (_opts: FetchOptions): Pick<Headers, 'get' | 's
   return opts._headers
 }
 
-export const getHeader = (options: FetchOptions, key: string) => normalizeHeaders(options).get(key)
-
-export const setHeader = (options: FetchOptions, key: string, value: string) => normalizeHeaders(options).set(key, value)
-
 export function createFetch ({ fetch }: CreateFetchOptions): $Fetch {
   function onError (request: FetchRequest, opts: FetchOptions, error?: Error, response?: FetchResponse<any>): Promise<FetchResponse<any>> {
     // Retry

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -41,6 +41,7 @@ export function normalizeHeaders (_opts: FetchOptions): Pick<Headers, 'get' | 's
     headers = Object.fromEntries(Object.entries(opts.headers).map(([key, value]) => [key.toLowerCase(), value]))
   }
 
+  opts.headers = headers
   opts._headers = {
     get: key => headers[key.toLowerCase()],
     has: key => key.toLowerCase() in headers,

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -62,9 +62,9 @@ describe('ohmyfetch', () => {
     expect(body2).to.deep.eq([{ num: 42 }, { num: 43 }])
 
     const headerFetches = [
-      [['Content-Type', 'text/html']],
+      [['Authorization', 'Bearer 123456']],
       [],
-      { 'Content-Type': 'text/html' },
+      { Authorization: 'Bearer 123456' },
       new Headers()
     ]
 
@@ -72,6 +72,22 @@ describe('ohmyfetch', () => {
       const { headers } = await $fetch(getURL('post'), { method: 'POST', body: { num: 42 }, headers: sentHeaders })
       expect(headers).to.include({ 'content-type': 'application/json' })
       expect(headers).to.include({ accept: 'application/json' })
+    }
+  })
+
+  it('allows overriding automatic headers', async () => {
+    const headers = new Headers()
+    headers.set('Content-Type', 'application/merge-patch+json')
+
+    const headerFetches = [
+      [['Content-Type', 'application/merge-patch+json']],
+      { 'Content-Type': 'application/merge-patch+json' },
+      headers
+    ]
+
+    for (const sentHeaders of headerFetches) {
+      const { headers } = await $fetch(getURL('post'), { method: 'POST', body: { num: 42 }, headers: sentHeaders })
+      expect(headers).to.include({ 'content-type': 'application/merge-patch+json' })
     }
   })
 


### PR DESCRIPTION
resolves #40 

This PR does three things:
* it normalizes headers to an object accepting get/set methods (internally), rather than on each get/set call, which should improve performance slightly
* it exposes a `getHeader` function in pair to `setHeader`
* it allows users to override `content-type` and `accept` headers 