### PR TITLE
fix: expose $fetch.create in CJS Proxy

### DIFF
--- a/cjs/index.cjs
+++ b/cjs/index.cjs
@@ -4,3 +4,4 @@ const createCaller = name => (input, init) => getExport(name).then(fn => fn(inpu
 exports.fetch = createCaller('fetch')
 exports.$fetch = createCaller('$fetch')
 exports.$fetch.raw = (input, init) => getExport('$fetch').then($fetch => $fetch.raw(input, init))
+exports.$fetch.create = (opts) => getExport('$fetch').then($fetch => $fetch.create(opts))

--- a/cjs/node.cjs
+++ b/cjs/node.cjs
@@ -4,3 +4,4 @@ const createCaller = name => (input, init) => getExport(name).then(fn => fn(inpu
 exports.fetch = createCaller('fetch')
 exports.$fetch = createCaller('$fetch')
 exports.$fetch.raw = (input, init) => getExport('$fetch').then($fetch => $fetch.raw(input, init))
+exports.$fetch.create = (opts) => getExport('$fetch').then($fetch => $fetch.create(opts))

--- a/cjs/undici.cjs
+++ b/cjs/undici.cjs
@@ -4,3 +4,4 @@ const createCaller = name => (input, init) => getExport(name).then(fn => fn(inpu
 exports.fetch = createCaller('fetch')
 exports.$fetch = createCaller('$fetch')
 exports.$fetch.raw = (input, init) => getExport('$fetch').then($fetch => $fetch.raw(input, init))
+exports.$fetch.create = (opts) => getExport('$fetch').then($fetch => $fetch.create(opts))


### PR DESCRIPTION
This allows to use $fetch.create in CJS environments. A caveat is that the function is not synchronous, but returns a promise.
See #44