### PR TITLE
fix: only serialize JSON bodies

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -105,22 +105,21 @@ export function createFetch (globalOptions: CreateFetchOptions): $Fetch {
         ctx.request = withQuery(ctx.request, ctx.options.params)
       }
       if (ctx.options.body && isPayloadMethod(ctx.options.method)) {
-        ctx.options.headers = new Headers(ctx.options.headers)
-
-        // Default to application/json for content-type and accept,
-        // when not explicitly set, and the body is JSON serializable.
         if (isJSONSerializable(ctx.options.body)) {
+          // Automatically JSON stringify request bodies, when not already a string.
+          ctx.options.body = typeof ctx.options.body === 'string'
+            ? ctx.options.body
+            : JSON.stringify(ctx.options.body)
+
+          // Set Content-Type and Accept headers to application/json by default
+          // for JSON serializable request bodies.
+          ctx.options.headers = new Headers(ctx.options.headers)
           if (!ctx.options.headers.has('content-type')) {
             ctx.options.headers.set('content-type', 'application/json')
           }
           if (!ctx.options.headers.has('accept')) {
             ctx.options.headers.set('accept', 'application/json')
           }
-        }
-
-        // Automatically stringify JSON bodies, if not already stringified.
-        if (ctx.options.headers.get('content-type') === 'application/json' && typeof ctx.options.body !== 'string') {
-          ctx.options.body = JSON.stringify(ctx.options.body)
         }
       }
     }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -105,15 +105,22 @@ export function createFetch (globalOptions: CreateFetchOptions): $Fetch {
         ctx.request = withQuery(ctx.request, ctx.options.params)
       }
       if (ctx.options.body && isPayloadMethod(ctx.options.method)) {
+        ctx.options.headers = new Headers(ctx.options.headers)
+
+        // Default to application/json for content-type and accept,
+        // when not explicitly set, and the body is JSON serializable.
         if (isJSONSerializable(ctx.options.body)) {
-          ctx.options.body = JSON.stringify(ctx.options.body)
-          ctx.options.headers = new Headers(ctx.options.headers)
           if (!ctx.options.headers.has('content-type')) {
             ctx.options.headers.set('content-type', 'application/json')
           }
           if (!ctx.options.headers.has('accept')) {
             ctx.options.headers.set('accept', 'application/json')
           }
+        }
+
+        // Automatically stringify JSON bodies, if not already stringified.
+        if (ctx.options.headers.get('content-type') === 'application/json' && typeof ctx.options.body !== 'string') {
+          ctx.options.body = JSON.stringify(ctx.options.body)
         }
       }
     }


### PR DESCRIPTION
Previously, everything that looked like it could be serialized, was actually serialized, no matter what content type was set.
This includes arbitrary strings. When you tried to send a string like `key "myval"` to the server using ohmyfetch, the server received `"key \\"myval\\""`.

Closes #58