### PR TITLE
fix: do not  retry when fetch is aborted

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -60,8 +60,12 @@ export function createFetch (globalOptions: CreateFetchOptions): $Fetch {
   const { fetch, Headers } = globalOptions
 
   function onError (ctx: FetchContext): Promise<FetchResponse<any>> {
+    // Is Abort
+    // If it is an active abort, it will not retry automatically.
+    // https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names
+    const isAbort = (ctx.error && ctx.error.name === 'AbortError') || false
     // Retry
-    if (ctx.options.retry !== false) {
+    if (ctx.options.retry !== false && !isAbort) {
       const retries = typeof ctx.options.retry === 'number'
         ? ctx.options.retry
         : (isPayloadMethod(ctx.options.method) ? 0 : 1)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -105,4 +105,14 @@ describe('ohmyfetch', () => {
     const err = await $fetch('', { baseURL: getURL('404'), retry: 3 }).catch(err => err)
     expect(err.request).to.equal(getURL('404'))
   })
+
+  it('abort with retry', () => {
+    const controller = new AbortController()
+    async function abortHandle () {
+      controller.abort()
+      const res = await $fetch('', { baseURL: getURL('ok'), retry: 3, signal: controller.signal })
+      console.log('res', res)
+    }
+    expect(abortHandle()).rejects.toThrow(/aborted/)
+  })
 })


### PR DESCRIPTION
Stop automatic retry by judging the wrong name【AbortError】、
https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names