### PR TITLE
fix: do not add baseURL to urls with protocol

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,5 @@
 import destr from 'destr'
-import { withBase, withQuery } from 'ufo'
+import { withBase, withQuery, hasProtocol } from 'ufo'
 import type { Fetch, RequestInfo, RequestInit, Response } from './types'
 import { createFetchError } from './error'
 import { isPayloadMethod, isJSONSerializable, detectResponseType, ResponseType, MappedType } from './utils'
@@ -98,7 +98,7 @@ export function createFetch (globalOptions: CreateFetchOptions): $Fetch {
     }
 
     if (typeof ctx.request === 'string') {
-      if (ctx.options.baseURL) {
+      if (ctx.options.baseURL && !hasProtocol(ctx.request)) {
         ctx.request = withBase(ctx.request, ctx.options.baseURL)
       }
       if (ctx.options.params) {


### PR DESCRIPTION
Currently:

```js
$fetch('https://test.com', { baseURL: 'https://foo.com' })
```

will make a request to `https://test.com/https://foo.com`.

We could also change the behaviour of `withBase` to do nothing if passed an absolute URL, but I think it makes more sense within `ohmyfetch`.