### PR TITLE
fix(types): allow synchronous interceptors to be passed

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -34,9 +34,9 @@ export interface FetchOptions<R extends ResponseType = ResponseType> extends Omi
   retry?: number | false
 
   onRequest?(ctx: FetchContext): Promise<void> | void
-  onRequestError?(ctx: FetchContext & { error: Error }): Promise<void>
-  onResponse?(ctx: FetchContext & { response: FetchResponse<R> }): Promise<void>
-  onResponseError?(ctx: FetchContext & { response: FetchResponse<R> }): Promise<void>
+  onRequestError?(ctx: FetchContext & { error: Error }): Promise<void> | void
+  onResponse?(ctx: FetchContext & { response: FetchResponse<R> }): Promise<void> | void
+  onResponseError?(ctx: FetchContext & { response: FetchResponse<R> }): Promise<void> | void
 }
 
 export interface $Fetch {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -33,7 +33,7 @@ export interface FetchOptions<R extends ResponseType = ResponseType> extends Omi
   response?: boolean
   retry?: number | false
 
-  onRequest?(ctx: FetchContext): Promise<void>
+  onRequest?(ctx: FetchContext): Promise<void> | void
   onRequestError?(ctx: FetchContext & { error: Error }): Promise<void>
   onResponse?(ctx: FetchContext & { response: FetchResponse<R> }): Promise<void>
   onResponseError?(ctx: FetchContext & { response: FetchResponse<R> }): Promise<void>


### PR DESCRIPTION
My English is not good, sorry I used a translator
Hi hello, I am using onRequest in $fetch.create in nuxt3, it throws an error, need to return a Promise? But I don't return anything and it seems to be working fine.
maybe it is possible to use union types to avoid this type error?

resolves https://github.com/unjs/ohmyfetch/issues/127