### PR TITLE
fix: always uppercase `method` option

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -142,6 +142,9 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
       error: undefined,
     };
 
+    // Uppercase method name
+    context.options.method = context.options.method?.toUpperCase();
+
     if (context.options.onRequest) {
       await context.options.onRequest(context);
     }
@@ -161,8 +164,6 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
         isPayloadMethod(context.options.method) &&
         isJSONSerializable(context.options.body)
       ) {
-        // Uppercase method name
-        context.options.method = context.options.method?.toUpperCase();
         // Automatically JSON stringify request bodies, when not already a string.
         context.options.body =
           typeof context.options.body === "string"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The JavaScript Fetch API supports lowercased `get`, `post`, `delete`, and `put` methods, but not the lowercased `patch` method. The `method` option in `ofetch` accepts a `string | undefined`, and the mentioned remark may be easy to forget without literal types. Therefore, it makes sense to standardize the behavior of all methods by converting them to uppercase. By convention, standardized methods are defined in all-uppercase, so this change should not break anything.

Additionally, the `isPayloadMethod` function already checks the method name by converting it to uppercase.

```typescript
// Works
fetch('https://dummyjson.com/products/1', {
    method: 'PATCH',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({ title: 'Test' }),
  })
    .then((res) => res.json())
    .then(console.log)

// Doesn't work
fetch('https://dummyjson.com/products/1', {
    method: 'patch', // <-- lowercased
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({ title: 'Test' }),
  })
    .then((res) => res.json())
    .then(console.log)

// Works
fetch('https://dummyjson.com/products/1', {
    method: 'put', // <-- also lowercased, but it works
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({ title: 'Test' }),
  })
    .then((res) => res.json())
    .then(console.log)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
