### PR TITLE
fix: remove fallback `500` status for client errors

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -59,12 +59,12 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         retries = isPayloadMethod(context.options.method) ? 0 : 1;
       }
 
-      const responseCode = (context.response && context.response.status) || 500;
       if (
         retries > 0 &&
-        (Array.isArray(context.options.retryStatusCodes)
-          ? context.options.retryStatusCodes.includes(responseCode)
-          : retryStatusCodes.has(responseCode))
+        (!context.response ||
+          (Array.isArray(context.options.retryStatusCodes)
+            ? context.options.retryStatusCodes.includes(context.response.status)
+            : retryStatusCodes.has(context.response.status)))
       ) {
         const retryDelay =
           typeof context.options.retryDelay === "function"


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #495

This PR removes the fallback `500` status for client errors.
❗ Noted that this might be a breaking change for users who rely on this fallback behavior.

When `500` is included in the `retryStatusCodes` (default):
Before and after are the same.

When `500` is excluded (manually):
Before: won't retry
After: will retry
