### PR TITLE
fix: prevent crash in legacy browsers on Headers init

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,7 +124,7 @@ function mergeHeaders(
   Headers: typeof globalThis.Headers
 ): Headers {
   if (!defaults) {
-    return new Headers(input);
+    return new Headers(input || {});
   }
   const headers = new Headers(defaults);
   if (input) {


### PR DESCRIPTION
The `mergeHeaders` function was passing `undefined` directly to `new Headers()` which crashes in Chrome 49 and other legacy browsers that don't support that syntax. Now defaults to empty object when input is undefined, matching the fix from #235.

Fixes #493