### PR TITLE
fix(utils): trim trailing whitespace from base URLs (resolves #530)

### DIFF
--- a/src/utils.url.ts
+++ b/src/utils.url.ts
@@ -38,11 +38,15 @@ export function joinURL(base?: string, path?: string): string {
  * Adds the base path to the input path, if it is not already present.
  */
 export function withBase(input = "", base = ""): string {
-  if (!base || base === "/") {
+  if (!base) {
+    return input;
+  }
+  const cleanedBase = String(base).trim();
+  if (cleanedBase === "/") {
     return input;
   }
 
-  const _base = withoutTrailingSlash(base);
+  const _base = withoutTrailingSlash(cleanedBase);
   if (input.startsWith(_base)) {
     return input;
   }
@@ -51,11 +55,16 @@ export function withBase(input = "", base = ""): string {
 }
 
 function withoutTrailingSlash(path?: string): string {
-  if (!path || path === "/") {
+  if (!path) {
     return "/";
   }
 
-  return path[path.length - 1] === "/" ? path.slice(0, -1) : path;
+  const trimmed = path.trimEnd();
+  if (trimmed === "/") {
+    return "/";
+  }
+
+  return trimmed[trimmed.length - 1] === "/" ? trimmed.slice(0, -1) : trimmed;
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -116,6 +116,16 @@ describe("ofetch", () => {
     );
   });
 
+  it("baseURL with trailing CR", async () => {
+    expect(
+      await $fetch("/x?foo=123", { baseURL: getURL("url") + "\r" })
+    ).to.equal("/url/x?foo=123");
+
+    expect(await $fetch("/x", { baseURL: getURL("url") + "\r" })).to.equal(
+      "/url/x"
+    );
+  });
+
   it("stringifies posts body automatically", async () => {
     const { body } = await $fetch(getURL("post"), {
       method: "POST",


### PR DESCRIPTION
Fixes a bug where baseURL values that include trailing control/whitespace characters (e.g., \r) caused incorrect URL merging (the path was dropped and only query params remained). This change trims trailing whitespace from the provided base before joining paths and adds a regression test.

```typescript
ofetch('/path', {
  baseURL: 'https://example.org/\r',
  query: { q: 'y' },
  onRequest: [({ request }) => console.log(request.toString())]
});

// wrong: https://example.org/?q=y
// expect: https://example.org/path?q=y
```