### PR TITLE
fix(types): add generics to \.create for typed FetchOptions

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -273,7 +273,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         ...globalOptions.defaults,
         ...customGlobalOptions.defaults,
         ...defaultOptions,
-      },
+      } as FetchOptions,
     });
 
   return $fetch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,10 @@ export interface $Fetch {
     options?: FetchOptions<R>
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
-  create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;
+  create<R extends ResponseType = ResponseType, T = any>(
+    defaults: FetchOptions<R, T>,
+    globalOptions?: CreateFetchOptions
+  ): $Fetch;
 }
 
 // --------------------------

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
 import { $fetch } from "../src/index.ts";
+import type { FetchOptions } from "../src/index.ts";
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;
@@ -503,6 +504,24 @@ describe("ofetch", () => {
     expect(onRequestError).not.toHaveBeenCalled();
     expect(onResponse).toHaveBeenCalledTimes(2);
     expect(onResponseError).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts explicitly typed FetchOptions<R> as create() defaults (issue #453)", () => {
+    // Passing FetchOptions<"json"> previously caused TS2345 because the `create`
+    // signature accepted bare `FetchOptions` (= FetchOptions<ResponseType>).
+    // Due to function-parameter contravariance, FetchContext<any,"json"> was not
+    // assignable to FetchContext<any, ResponseType>, producing a compile error.
+    const jsonOpts: FetchOptions<"json"> = {
+      baseURL: "https://api.example.com",
+      retryDelay: (_ctx) => 500,
+    };
+    expect(typeof $fetch.create(jsonOpts)).toBe("function");
+
+    const blobOpts: FetchOptions<"blob"> = {
+      baseURL: "https://api.example.com",
+      responseType: "blob",
+    };
+    expect(typeof $fetch.create(blobOpts)).toBe("function");
   });
 
   it("default fetch options", async () => {


### PR DESCRIPTION
## Problem

Fixes #453.

When calling \.create() with an explicitly typed \FetchOptions<R>\ argument (e.g. \FetchOptions<'json'>\), TypeScript raises a type error because the \create\ method signature accepts the bare \FetchOptions\ (equivalent to \FetchOptions<ResponseType, any>\).

The error occurs because \FetchOptions\ includes callback properties like \etryDelay\ typed as \(context: FetchContext<T, R>) => number\. Due to function parameter contravariance, \FetchOptions<'json'>\ is not assignable to \FetchOptions<ResponseType>\ — \FetchContext<any, 'json'>\ is not assignable to \FetchContext<any, ResponseType>\.

**Reproduction (from the issue):**
\\\	s
// Previously errored:
const opts: FetchOptions<'json'> = {
  baseURL: 'https://api.example.com',
  retryDelay: (ctx) => 500, // ctx is FetchContext<any, 'json'>
}
const client = \.create(opts) // TS2345 error
\\\

## Fix

Add \<R extends ResponseType = ResponseType, T = any>\ generics to the \create\ method in the \\\ interface, so TypeScript infers the response type from the passed defaults rather than widening it unconditionally to \ResponseType\.

\\\	s
// Before
create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): \;

// After
create<R extends ResponseType = ResponseType, T = any>(
  defaults: FetchOptions<R, T>,
  globalOptions?: CreateFetchOptions
): \;
\\\

A \s FetchOptions\ cast is added in the implementation (\etch.ts\) where the spread of defaults from multiple sources (each potentially typed with different \R\) is assigned to \CreateFetchOptions.defaults\. This cast is semantically correct — the merged object serves as global defaults that must accommodate any response type at runtime.

## Verification

- \	sc --noEmit\  
- \itest run\ — 28/28 tests 