### PR TITLE
feat: merge hooks from defaults and per-request options

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import type {
   FetchContext,
   FetchHook,
+  FetchHooks,
   FetchOptions,
   FetchRequest,
   ResolvedFetchOptions,
@@ -109,13 +110,49 @@ export function resolveFetchOptions<
     };
   }
 
+  // Merge hooks: concatenate defaults and input hooks (defaults run first)
+  const mergedHooks = mergeHooks(
+    defaults as FetchOptions | undefined,
+    input as FetchOptions | undefined
+  );
+
   return {
     ...defaults,
     ...input,
+    ...mergedHooks,
     query,
     params: query,
     headers,
   };
+}
+
+const hookNames: Array<keyof FetchHooks> = [
+  "onRequest",
+  "onRequestError",
+  "onResponse",
+  "onResponseError",
+];
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function mergeHooks(
+  defaults: FetchOptions | undefined,
+  input: FetchOptions | undefined
+): Partial<FetchHooks> {
+  const merged: Partial<FetchHooks> = {};
+  for (const name of hookNames) {
+    const defaultHooks = toArray((defaults as any)?.[name]);
+    const inputHooks = toArray((input as any)?.[name]);
+    if (defaultHooks.length > 0 || inputHooks.length > 0) {
+      (merged as any)[name] = [...defaultHooks, ...inputHooks];
+    }
+  }
+  return merged;
 }
 
 function mergeHeaders(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -505,6 +505,89 @@ describe("ofetch", () => {
     expect(onResponseError).toHaveBeenCalledTimes(2);
   });
 
+  describe("hook merging", () => {
+    it("merges default and per-request hooks (defaults run first)", async () => {
+      const order: string[] = [];
+      const customFetch = $fetch.create({
+        onRequest() {
+          order.push("default");
+        },
+      });
+      await customFetch(getURL("ok"), {
+        onRequest() {
+          order.push("per-request");
+        },
+      });
+      expect(order).toEqual(["default", "per-request"]);
+    });
+
+    it("merges array hooks from defaults and per-request", async () => {
+      const order: string[] = [];
+      const customFetch = $fetch.create({
+        onRequest: [
+          () => {
+            order.push("default-1");
+          },
+          () => {
+            order.push("default-2");
+          },
+        ],
+      });
+      await customFetch(getURL("ok"), {
+        onRequest: [
+          () => {
+            order.push("per-request-1");
+          },
+          () => {
+            order.push("per-request-2");
+          },
+        ],
+      });
+      expect(order).toEqual([
+        "default-1",
+        "default-2",
+        "per-request-1",
+        "per-request-2",
+      ]);
+    });
+
+    it("works when only defaults have hooks", async () => {
+      const onRequest = vi.fn();
+      const customFetch = $fetch.create({ onRequest });
+      await customFetch(getURL("ok"));
+      expect(onRequest).toHaveBeenCalledOnce();
+    });
+
+    it("works when only per-request has hooks", async () => {
+      const onRequest = vi.fn();
+      const customFetch = $fetch.create({});
+      await customFetch(getURL("ok"), { onRequest });
+      expect(onRequest).toHaveBeenCalledOnce();
+    });
+
+    it("merges all hook types", async () => {
+      const defaultOnResponse = vi.fn();
+      const defaultOnResponseError = vi.fn();
+      const perRequestOnResponse = vi.fn();
+      const perRequestOnResponseError = vi.fn();
+
+      const customFetch = $fetch.create({
+        onResponse: defaultOnResponse,
+        onResponseError: defaultOnResponseError,
+      });
+
+      await customFetch(getURL("403"), {
+        onResponse: perRequestOnResponse,
+        onResponseError: perRequestOnResponseError,
+      }).catch(() => {});
+
+      expect(defaultOnResponse).toHaveBeenCalledOnce();
+      expect(perRequestOnResponse).toHaveBeenCalledOnce();
+      expect(defaultOnResponseError).toHaveBeenCalledOnce();
+      expect(perRequestOnResponseError).toHaveBeenCalledOnce();
+    });
+  });
+
   it("default fetch options", async () => {
     await $fetch("https://jsonplaceholder.typicode.com/todos/1", {});
     expect(fetch).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Hooks from `$fetch.create()` defaults and per-request options are now **concatenated** instead of overwritten
- Default hooks run first, followed by per-request hooks
- Applies to all hook types: `onRequest`, `onRequestError`, `onResponse`, `onResponseError`

## Problem

Currently, per-request hooks completely replace default hooks set via `$fetch.create()`:

```ts
const api = $fetch.create({
  onRequest() { /* logging - this gets lost! */ }
})

api('/endpoint', {
  onRequest() { /* transform */ }
})
```

## Solution

Hooks are now merged using array concatenation (same pattern as `got.extend()`):

```ts
const api = $fetch.create({
  onRequest() { console.log('log') }  // runs first
})

api('/endpoint', {
  onRequest() { console.log('transform') }  // runs second
})
// Output: "log", "transform"
```

Array hooks also merge correctly:

```ts
const api = $fetch.create({
  onRequest: [hookA, hookB]
})

api('/endpoint', {
  onRequest: [hookC, hookD]
})
// Execution order: hookA → hookB → hookC → hookD
```

## Test plan

- [x] Default + per-request single hooks merge in correct order
- [x] Default + per-request array hooks merge in correct order
- [x] Works when only defaults have hooks
- [x] Works when only per-request has hooks
- [x] All hook types merge (`onResponse`, `onResponseError`, etc.)
- [x] All existing tests pass
- [x] Lint, typecheck, build pass

Resolves #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request lifecycle hooks now merge when configured in both default and per-request settings. Hook handlers execute sequentially—defaults run first, followed by per-request hooks—rather than per-request hooks replacing defaults entirely. This enhancement applies to all lifecycle hooks: onRequest, onResponse, onRequestError, and onResponseError.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->