### PR TITLE
feat: add isFetchError type guard

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -65,3 +65,7 @@ export function createFetchError<T = any>(
 
   return fetchError;
 }
+
+export function isFetchError<T = any>(error: unknown): error is FetchError<T> {
+  return error instanceof FetchError;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ import {
 } from "vitest";
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
-import { $fetch } from "../src/index.ts";
+import { $fetch, FetchError, isFetchError } from "../src/index.ts";
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;
@@ -522,6 +522,39 @@ describe("ofetch", () => {
       headers: expect.any(Headers),
       signal: expect.any(AbortSignal),
       timeout: 10_000,
+    });
+  });
+
+  describe("isFetchError", () => {
+    it("returns true for FetchError instances", async () => {
+      const error = await $fetch(getURL("404")).catch((error_: any) => error_);
+      expect(isFetchError(error)).toBe(true);
+      expect(error).toBeInstanceOf(FetchError);
+    });
+
+    it("returns false for non-FetchError values", () => {
+      expect(isFetchError(new Error("test"))).toBe(false);
+      // eslint-disable-next-line unicorn/no-null
+      expect(isFetchError(null)).toBe(false);
+      expect(isFetchError(undefined)).toBe(false);
+      expect(isFetchError("string")).toBe(false);
+      expect(isFetchError({})).toBe(false);
+    });
+
+    it("narrows type correctly", async () => {
+      const error: unknown = await $fetch(getURL("403")).catch(
+        (error_: any) => error_
+      );
+      if (isFetchError(error)) {
+        expect(error.status).toBe(403);
+        expect(error.statusText).toBe("Forbidden");
+        expect(error.data).toBeDefined();
+        expect(error.request).toBeDefined();
+        expect(error.options).toBeDefined();
+        expect(error.response).toBeDefined();
+      } else {
+        throw new Error("Expected FetchError");
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `isFetchError()` type guard for safe error narrowing in catch blocks
- Exported from package root alongside `FetchError`

## Usage

```ts
import { $fetch, isFetchError } from 'ofetch'

try {
  await $fetch('/api/endpoint')
} catch (error) {
  if (isFetchError(error)) {
    // error is now typed as FetchError
    console.log(error.status)      // number | undefined
    console.log(error.data)        // parsed response body
    console.log(error.statusText)  // string | undefined
    console.log(error.response)    // FetchResponse | undefined
  }
}
```

## Test plan

- [x] Returns `true` for FetchError instances
- [x] Returns `false` for Error, null, undefined, string, plain objects
- [x] Narrows type correctly — accessing `.status`, `.data`, `.response` etc.
- [x] All existing tests pass (31 tests)
- [x] Lint, typecheck, build pass

Resolves #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a type-guard utility function for safely identifying and narrowing fetch errors, enhancing error handling reliability.

* **Tests**
  * Added test suite validating the new type-guard function against multiple error types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->