### PR TITLE
feat: add HTTP method aliases ($fetch.get, .post, .put, etc.)

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -276,5 +276,18 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       },
     });
 
+  for (const method of [
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "head",
+    "options",
+  ] as const) {
+    $fetch[method] = (request, options) =>
+      $fetch(request, { ...options, method } as any);
+  }
+
   return $fetch;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,11 @@
 // $fetch API
 // --------------------------
 
+type HttpMethodFn = <T = any, R extends ResponseType = "json">(
+  request: FetchRequest,
+  options?: Omit<FetchOptions<R>, "method">
+) => Promise<MappedResponseType<R, T>>;
+
 export interface $Fetch {
   <T = any, R extends ResponseType = "json">(
     request: FetchRequest,
@@ -13,6 +18,13 @@ export interface $Fetch {
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
   create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;
+  get: HttpMethodFn;
+  post: HttpMethodFn;
+  put: HttpMethodFn;
+  delete: HttpMethodFn;
+  patch: HttpMethodFn;
+  head: HttpMethodFn;
+  options: HttpMethodFn;
 }
 
 // --------------------------

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -505,6 +505,51 @@ describe("ofetch", () => {
     expect(onResponseError).toHaveBeenCalledTimes(2);
   });
 
+  describe("method aliases", () => {
+    it("$fetch.get()", async () => {
+      const result = await $fetch.get(getURL("echo"));
+      expect(result.path).toBe("/echo");
+    });
+
+    it("$fetch.post()", async () => {
+      const { body, headers } = await $fetch.post(getURL("post"), {
+        body: { foo: "bar" },
+      });
+      expect(body).toEqual({ foo: "bar" });
+      expect(headers["content-type"]).toBe("application/json");
+    });
+
+    it("$fetch.put()", async () => {
+      const { body } = await $fetch.put(getURL("post"), {
+        body: { updated: true },
+      });
+      expect(body).toEqual({ updated: true });
+    });
+
+    it("$fetch.delete()", async () => {
+      const result = await $fetch.delete(getURL("echo"));
+      expect(result.path).toBe("/echo");
+    });
+
+    it("$fetch.patch()", async () => {
+      const { body } = await $fetch.patch(getURL("post"), {
+        body: { patched: true },
+      });
+      expect(body).toEqual({ patched: true });
+    });
+
+    it("$fetch.head()", async () => {
+      const result = await $fetch.head(getURL("ok"));
+      expect(result).toBeUndefined();
+    });
+
+    it("method aliases work with create()", async () => {
+      const api = $fetch.create({ baseURL: getURL("") });
+      const result = await api.get("echo");
+      expect(result.path).toBe("/echo");
+    });
+  });
+
   it("default fetch options", async () => {
     await $fetch("https://jsonplaceholder.typicode.com/todos/1", {});
     expect(fetch).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Add shorthand methods: `$fetch.get()`, `$fetch.post()`, `$fetch.put()`, `$fetch.delete()`, `$fetch.patch()`, `$fetch.head()`, `$fetch.options()`
- `method` is omitted from options type for type safety
- Works with `$fetch.create()` instances

## Usage

```ts
// Before
await $fetch('/api/users', { method: 'GET' })
await $fetch('/api/users', { method: 'POST', body: { name: 'John' } })

// After
await $fetch.get('/api/users')
await $fetch.post('/api/users', { body: { name: 'John' } })
await $fetch.delete('/api/users/1')
await $fetch.patch('/api/users/1', { body: { name: 'Jane' } })

// Works with create()
const api = $fetch.create({ baseURL: 'https://api.example.com' })
await api.get('/users')
await api.post('/users', { body: { name: 'John' } })
```

## Test plan

- [x] `$fetch.get()` — GET request
- [x] `$fetch.post()` — POST with JSON body
- [x] `$fetch.put()` — PUT with JSON body
- [x] `$fetch.delete()` — DELETE request
- [x] `$fetch.patch()` — PATCH with JSON body
- [x] `$fetch.head()` — HEAD request (no body)
- [x] Method aliases work with `$fetch.create()`
- [x] All existing tests pass (35 tests)
- [x] Lint, typecheck, build pass

Resolves #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP method shortcuts (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) to the fetch API for more concise request syntax.

* **Tests**
  * Added comprehensive test coverage for the new HTTP method shortcuts, including response validation and path composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->