### PR TITLE
fix: legacy browser Headers crash, onRequest params merge, baseURL whitespace

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -115,9 +115,15 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       if (context.options.baseURL) {
         context.request = withBase(context.request, context.options.baseURL);
       }
+      // Merge params into query (params may be set in onRequest hook)
+      if (context.options.params) {
+        context.options.query = {
+          ...context.options.query,
+          ...context.options.params,
+        };
+      }
       if (context.options.query) {
         context.request = withQuery(context.request, context.options.query);
-        delete context.options.query;
       }
       if ("query" in context.options) {
         delete context.options.query;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,7 +124,7 @@ function mergeHeaders(
   Headers: typeof globalThis.Headers
 ): Headers {
   if (!defaults) {
-    return new Headers(input);
+    return input ? new Headers(input) : new Headers();
   }
   const headers = new Headers(defaults);
   if (input) {

--- a/src/utils.url.ts
+++ b/src/utils.url.ts
@@ -38,6 +38,10 @@ export function joinURL(base?: string, path?: string): string {
  * Adds the base path to the input path, if it is not already present.
  */
 export function withBase(input = "", base = ""): string {
+  // Trim control characters and whitespace from base URL
+  // (can happen from .env parsing mistakes)
+  base = base.trim();
+
   if (!base || base === "/") {
     return input;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -524,4 +524,45 @@ describe("ofetch", () => {
       timeout: 10_000,
     });
   });
+
+  describe("bugfixes", () => {
+    it("handles undefined headers without crash (#493)", async () => {
+      // Should not throw when no headers are provided
+      const result = await $fetch(getURL("ok"), {});
+      expect(result).toBe("ok");
+    });
+
+    it("merges params set in onRequest hook (#477)", async () => {
+      const { path } = await $fetch(getURL("echo"), {
+        query: { a: 1 },
+        onRequest(ctx) {
+          ctx.options.params = { b: 2 };
+        },
+      });
+      const params = Object.fromEntries(new URL(path, "http://_").searchParams);
+      expect(params).toMatchObject({ a: "1", b: "2" });
+    });
+
+    it("merges query set in onRequest hook", async () => {
+      const { path } = await $fetch(getURL("echo"), {
+        onRequest(ctx) {
+          ctx.options.query = { dynamic: "true" };
+        },
+      });
+      const params = Object.fromEntries(new URL(path, "http://_").searchParams);
+      expect(params).toMatchObject({ dynamic: "true" });
+    });
+
+    it("trims whitespace from baseURL (#530)", async () => {
+      const result = await $fetch("/x?foo=123", {
+        baseURL: getURL("url") + " ",
+      });
+      expect(result).toBe("/url/x?foo=123");
+
+      const result2 = await $fetch("/x?foo=123", {
+        baseURL: getURL("url") + "\t",
+      });
+      expect(result2).toBe("/url/x?foo=123");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Three bug fixes in one PR:

### 1. Legacy browser `Headers` crash (#493)
`new Headers(undefined)` crashes in Chrome 49 and other legacy browsers. Now defaults to `new Headers()` when input is undefined.

### 2. onRequest params not merged into URL (#477)
When setting `ctx.options.params` in an `onRequest` hook, the params were not merged into the URL query string. Now `params` set in hooks are merged with existing `query` before URL construction.

### 3. baseURL trailing whitespace breaks URL merge (#530)
When `baseURL` has trailing whitespace or control characters (e.g. from `.env` parsing), URL merging breaks. Now `base` is trimmed before processing.

## Test plan

- [x] No crash when headers are undefined
- [x] Params set in `onRequest` hook merge with existing query
- [x] Query set in `onRequest` hook is applied
- [x] baseURL with trailing space/tab works correctly
- [x] All existing tests pass (32 tests)
- [x] Lint, typecheck, build pass

Fixes #493, #477, #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header initialization to prevent crashes when headers are undefined.
  * Improved query parameter merging when set dynamically during request processing.
  * Enhanced base URL handling by trimming whitespace from base paths.

* **Tests**
  * Added comprehensive test coverage for bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->