### PR TITLE
feat: add $fetch.safe() for Go-like error handling

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -263,6 +263,15 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
   $fetch.raw = $fetchRaw;
 
+  $fetch.safe = async (request, options) => {
+    try {
+      const data = await $fetch(request, options);
+      return { data, error: undefined };
+    } catch (error) {
+      return { data: undefined, error: error as any };
+    }
+  };
+
   $fetch.native = (...args) => fetch(...args);
 
   $fetch.create = (defaultOptions = {}, customGlobalOptions = {}) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@
 // $fetch API
 // --------------------------
 
+export type SafeResult<T, E = IFetchError> =
+  | { data: T; error: undefined }
+  | { data: undefined; error: E };
+
 export interface $Fetch {
   <T = any, R extends ResponseType = "json">(
     request: FetchRequest,
@@ -13,6 +17,11 @@ export interface $Fetch {
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
   create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;
+  /** Returns `{ data, error }` instead of throwing. */
+  safe<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<SafeResult<MappedResponseType<R, T>>>;
 }
 
 // --------------------------

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -505,6 +505,45 @@ describe("ofetch", () => {
     expect(onResponseError).toHaveBeenCalledTimes(2);
   });
 
+  describe("safe fetch", () => {
+    it("returns { data, error: undefined } on success", async () => {
+      const result = await $fetch.safe(getURL("ok"));
+      expect(result.data).toBe("ok");
+      expect(result.error).toBeUndefined();
+    });
+
+    it("returns { data: undefined, error } on failure", async () => {
+      const result = await $fetch.safe(getURL("404"));
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+      expect(result.error?.status).toBe(404);
+    });
+
+    it("returns { data: undefined, error } on network error", async () => {
+      const result = await $fetch.safe("http://localhost:1");
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
+
+    it("error narrows type correctly", async () => {
+      const result = await $fetch.safe(getURL("403"));
+      if (result.error) {
+        expect(result.data).toBeUndefined();
+        expect(result.error.status).toBe(403);
+        expect(result.error.statusText).toBe("Forbidden");
+      } else {
+        throw new Error("Expected error");
+      }
+    });
+
+    it("works with create()", async () => {
+      const api = $fetch.create({ baseURL: getURL("") });
+      const result = await api.safe("ok");
+      expect(result.data).toBe("ok");
+      expect(result.error).toBeUndefined();
+    });
+  });
+
   it("default fetch options", async () => {
     await $fetch("https://jsonplaceholder.typicode.com/todos/1", {});
     expect(fetch).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Add `$fetch.safe()` that returns `{ data, error }` instead of throwing
- Type-safe discriminated union: `SafeResult<T>`
- Works with `$fetch.create()` instances

## Usage

```ts
// Before (try/catch)
try {
  const data = await $fetch('/api/users')
} catch (error) {
  if (isFetchError(error)) {
    console.log(error.status)
  }
}

// After (Go-like)
const { data, error } = await $fetch.safe('/api/users')
if (error) {
  console.log(error.status) // typed as IFetchError
  return
}
console.log(data) // typed as T
```

Type narrowing works automatically:
```ts
const result = await $fetch.safe<User>('/api/user/1')

if (result.error) {
  // result.data is undefined here
  console.error(result.error.status)
  return
}

// result.data is User here
console.log(result.data.name)
```

## Test plan

- [x] Returns `{ data, error: undefined }` on success
- [x] Returns `{ data: undefined, error }` on HTTP error (404, 403)
- [x] Returns `{ data: undefined, error }` on network error
- [x] Error has correct status/statusText properties
- [x] Works with `$fetch.create()` instances
- [x] All existing tests pass (33 tests)
- [x] Lint, typecheck, build pass

Resolves #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `.safe()` method for fetch operations that returns a structured result object containing either the successful response data or detailed error information, instead of throwing exceptions. This method handles all scenarios uniformly—successful HTTP responses, error statuses (4xx/5xx), and network failures—providing an alternative approach to error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->