### PR TITLE
fix: pass generic type T through to FetchOptions in  interface (#559)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,11 @@
 export interface $Fetch {
   <T = any, R extends ResponseType = "json">(
     request: FetchRequest,
-    options?: FetchOptions<R>
+    options?: FetchOptions<R, T>
   ): Promise<MappedResponseType<R, T>>;
   raw<T = any, R extends ResponseType = "json">(
     request: FetchRequest,
-    options?: FetchOptions<R>
+    options?: FetchOptions<R, T>
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
   create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;


### PR DESCRIPTION
## Problem

The `` interface accepts `<T, R>` generics but only passes `R` to `FetchOptions<R>`, leaving `T` defaulting to `any`. This means `FetchContext` and `FetchResponse` in hooks always have `any` type:

```ts
const instance = ofetch.create(defaultOptions)
instance<Data>("", {
  onResponse: context => {
    context.response // is FetchResponse<any> — should be FetchResponse<Data>
  }
})
```

## Fix

Pass `T` through to `FetchOptions` in both the main call and `raw` method:

```diff
- options?: FetchOptions<R>
+ options?: FetchOptions<R, T>
```

This is a pure type-level change with no runtime impact.

## Related

Fixes #559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced the type system for request handling to improve type accuracy, provide better IDE autocompletion, and strengthen type validation across API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->