### PR TITLE
fix: pass type parameter T to FetchOptions in $Fetch interface (#559)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,11 @@
 export interface $Fetch {
   <T = any, R extends ResponseType = "json">(
     request: FetchRequest,
-    options?: FetchOptions<R>
+    options?: FetchOptions<R, T>
   ): Promise<MappedResponseType<R, T>>;
   raw<T = any, R extends ResponseType = "json">(
     request: FetchRequest,
-    options?: FetchOptions<R>
+    options?: FetchOptions<R, T>
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
   create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #559

### 📝 Description

The generic type `T` on `` call signatures was not being forwarded to `FetchOptions`. This caused `onResponse` callbacks to always receive `FetchResponse<any>` instead of `FetchResponse<T>`, even when the user explicitly specified the response type.

### Before

```ts
const instance = ofetch.create(defaultOptions)

instance<Data>("", {
  onResponse: context => {
    context.response // FetchResponse<any> ❌
  }
})
```

### After

```ts
const instance = ofetch.create(defaultOptions)

instance<Data>("", {
  onResponse: context => {
    context.response // FetchResponse<Data> ✅
  }
})
```

### Changes

In `src/types.ts`, changed `FetchOptions<R>` to `FetchOptions<R, T>` in both the call and raw signatures of the `` interface. This ensures the `T` type parameter flows through to `FetchHooks<T, R>` and ultimately to `FetchResponse<T>` in the `onResponse` callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type propagation in fetch API signatures for improved type safety and IDE support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->