### PR TITLE
allow JSON bodies with buffer properties

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function isJSONSerializable(value: any): boolean {
   if (Array.isArray(value)) {
     return true;
   }
-  if (value.buffer) {
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
     return false;
   }
   // `FormData` and `URLSearchParams` should't have a `toJSON` method,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -158,6 +158,15 @@ describe("ofetch", () => {
     }
   });
 
+  it("stringifies plain objects with a buffer property", async () => {
+    const { body } = await $fetch(getURL("post"), {
+      method: "POST",
+      body: { buffer: "text", nested: { ok: true } },
+    });
+
+    expect(body).to.deep.eq({ buffer: "text", nested: { ok: true } });
+  });
+
   it("does not stringify body when content type != application/json", async () => {
     const message = '"Hallo von Pascal"';
     const { body } = await $fetch(getURL("echo"), {


### PR DESCRIPTION

**Repo:** unjs/ofetch (⭐ 5000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +10/-1

## What
This change fixes `isJSONSerializable` so it only treats actual binary payloads such as typed arrays and `ArrayBuffer` instances as non-JSON bodies. Plain objects that happen to contain a `buffer` field now keep the normal JSON request path, and a regression test was added to cover that case.

## Why
The previous `value.buffer` check was too broad and misclassified ordinary JSON payloads like `{ buffer: "text" }` as non-serializable. That can break valid request bodies in real APIs where `buffer` is just a domain field, so narrowing the check to real binary types restores expected behavior without affecting `Buffer` or typed-array handling.

## Testing
Added a targeted regression test in `test/index.test.ts` for a JSON body with a `buffer` property. Attempted to run `pnpm exec vitest run test/index.test.ts -t "stringifies plain objects with a buffer property"`, but the sandbox denied pnpm from creating its global cache temp directory under `/Users/bojun/Library/pnpm`.

## Risk
Low / The change only narrows binary detection to actual `ArrayBuffer`-backed types and adds direct test coverage for the corrected behavior.
