### PR TITLE
fix(utils): handle null in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,11 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {


### PR DESCRIPTION
Fixes #571

Two bugs in isJSONSerializable:

1. The comparison t === null is dead code � typeof never returns the string 'null', so this condition can never be true.
2. When value is null, it bypasses the early returns, reaches if (value.buffer), and throws TypeError: Cannot read properties of null (reading 'buffer').

Fix: add an explicit value === null guard immediately after the undefined check and return true (null is valid JSON). Remove the dead t === null from the typeof comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and consistency for better maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/575)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->