### PR TITLE
fix(utils.url): require boundary char in withBase prefix match (#564)

### DIFF
--- a/src/utils.url.ts
+++ b/src/utils.url.ts
@@ -36,6 +36,12 @@ export function joinURL(base?: string, path?: string): string {
 
 /**
  * Adds the base path to the input path, if it is not already present.
+ *
+ * The base-already-present short-circuit requires the character after the
+ * base to be a URL boundary (`/`, `?`, `#`) or end-of-string. Without the
+ * boundary check, an attacker-controlled `input` such as
+ * `http://api.internal.attacker.com/...` would be accepted as-if it already
+ * had the `http://api.internal` base and skip the join (CWE-918 SSRF).
  */
 export function withBase(input = "", base = ""): string {
   if (!base || base === "/") {
@@ -44,7 +50,15 @@ export function withBase(input = "", base = ""): string {
 
   const _base = withoutTrailingSlash(base);
   if (input.startsWith(_base)) {
-    return input;
+    const nextChar = input[_base.length];
+    if (
+      nextChar === undefined ||
+      nextChar === "/" ||
+      nextChar === "?" ||
+      nextChar === "#"
+    ) {
+      return input;
+    }
   }
 
   return joinURL(_base, input);

--- a/test/utils.url.test.ts
+++ b/test/utils.url.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { withBase } from "../src/utils.url.ts";
+
+describe("withBase", () => {
+  it("returns the input unchanged when base is empty", () => {
+    expect(withBase("/foo", "")).toBe("/foo");
+  });
+
+  it("returns the input unchanged when base is '/'", () => {
+    expect(withBase("/foo", "/")).toBe("/foo");
+  });
+
+  it("joins base and input when input lacks the base", () => {
+    expect(withBase("/foo", "https://api.example.com")).toBe(
+      "https://api.example.com/foo"
+    );
+  });
+
+  it("returns input unchanged when input already starts with base and the boundary is '/'", () => {
+    expect(
+      withBase("https://api.example.com/x", "https://api.example.com")
+    ).toBe("https://api.example.com/x");
+  });
+
+  it("returns input unchanged when input equals base exactly", () => {
+    expect(withBase("https://api.example.com", "https://api.example.com")).toBe(
+      "https://api.example.com"
+    );
+  });
+
+  it("returns input unchanged when boundary is '?'", () => {
+    expect(
+      withBase("https://api.example.com?q=1", "https://api.example.com")
+    ).toBe("https://api.example.com?q=1");
+  });
+
+  it("returns input unchanged when boundary is '#'", () => {
+    expect(
+      withBase("https://api.example.com#frag", "https://api.example.com")
+    ).toBe("https://api.example.com#frag");
+  });
+
+  // Regression test for issue #564: previously, an input like
+  // "http://api.internal.attacker.com/steal" would be returned unchanged
+  // when base was "http://api.internal", because it merely starts with the
+  // base string. That bypass let attacker-controlled inputs reach arbitrary
+  // hosts. The fix requires a URL boundary character after the base.
+  it("rejects boundary-less prefix match and joins instead (SSRF guard)", () => {
+    expect(
+      withBase("http://api.internal.attacker.com/steal", "http://api.internal")
+    ).toBe("http://api.internal/http://api.internal.attacker.com/steal");
+  });
+});


### PR DESCRIPTION
Fixes #564.

`withBase(input, base)` previously returned `input` unchanged whenever `input.startsWith(base)` was true. An attacker-controlled input like `http://api.internal.attacker.com/steal` satisfies `startsWith("http://api.internal")` and bypasses the base-URL enforcement, reaching an arbitrary host (CWE-918 SSRF / authority-override).

This change requires the character after the base to be a URL boundary (`/`, `?`, `#`) or end-of-string before short-circuiting. Otherwise the input is joined with the base as a path segment, matching what callers using `baseURL` expect.

Adds `test/utils.url.test.ts` with 8 unit tests covering existing behaviour (`/`, `?`, `#`, exact match, no-base, base-less input) and the new boundary guard. The regression test fails on the pre-fix code and passes after.

Full suite: `pnpm vitest run` -> 36/36 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL base-joining logic to correctly validate boundary characters when determining if input already includes the base path.

* **Tests**
  * Added comprehensive test coverage for URL base handling, including boundary edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/576)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->