### PR TITLE
fix: handle null in isJSONSerializable (#571)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,11 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {


### PR DESCRIPTION
Fixes #571

## Problem

The `isJSONSerializable` function has a bug with `null` values:

1. `typeof null` returns `"object"`, not `null", so `t === null` is dead code
2. `null` is valid JSON (`JSON.stringify(null)` === `"null"`), so it should be detected as JSON serializable
3. Passing `null` to the function throws: `TypeError: Cannot read properties of null (reading 'buffer')`

## Fix

Check `value === null` explicitly before the `typeof` checks. Since `null` is valid JSON, return `true`.

```diff
 export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of null values in JSON serialization checks, ensuring they are now correctly identified as serializable data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/577)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->