### PR TITLE
fix: check null before typeof in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function isJSONSerializable(value: any): boolean {
     return false;
   }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (value === null || t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {


### PR DESCRIPTION
## Problem

`isJSONSerializable(null)` throws:

```
Uncaught TypeError: Cannot read properties of null (reading buffer)
    at isJSONSerializable
```

## Root Cause

`typeof null` returns `"object"`, not `null`. So `t === null` (where `t = typeof value`) is always `false` — it is dead code. When `value` is `null`, it falls through to the object branch and crashes on `value.buffer` access.

## Fix

Move the null check to use `value === null` before the typeof comparison:

```diff
- if (t === "string" || t === "number" || t === "boolean" || t === null) {
+ if (value === null || t === "string" || t === "number" || t === "boolean") {
```

Fixes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed JSON serialization validation to correctly recognize null values as JSON-serializable, improving data type checking accuracy across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/578)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->