### PR TITLE
fix(utils): handle null in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,11 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {


### PR DESCRIPTION
## Summary
Fixed `isJSONSerializable(null)` throwing `TypeError` and returning incorrect result.

## Root cause
- `typeof null` returns `"object"`, so `t === null` was dead code
- The null value fell through to `value.buffer` which threw `TypeError: Cannot read properties of null`

## Fix
Added an explicit `value === null` check before the typeof check, returning `true` since `null` is JSON serializable.

Closes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serialization validation to properly handle `null` values, preventing errors and ensuring accurate validation of data structures containing null entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->