### PR TITLE
Prefer explicit method option in fetch errors

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -24,7 +24,7 @@ export function createFetchError<T = any>(
   const errorMessage = ctx.error?.message || ctx.error?.toString() || "";
 
   const method =
-    (ctx.request as Request)?.method || ctx.options?.method || "GET";
+    ctx.options?.method || (ctx.request as Request)?.method || "GET";
   const url = (ctx.request as Request)?.url || String(ctx.request) || "/";
   const requestStr = `[${method}] ${JSON.stringify(url)}`;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -321,6 +321,18 @@ describe("ofetch", () => {
     expect(error.response?._data).to.deep.eq(error.data);
   });
 
+  it("prefers options method over request method in error", async () => {
+    const error = await $fetch(
+      new Request(getURL("/403"), { method: "GET" }),
+      { method: "POST" }
+    ).catch((error: any) => error);
+    expect(error.toString()).toBe(
+      `FetchError: [POST] "${getURL("403")}": 403 Forbidden`
+    );
+    expect(error.request).toBeInstanceOf(Request);
+    expect(error.options.method).to.equal("POST");
+  });
+
   it("aborting on timeout", async () => {
     const noTimeout = $fetch(getURL("timeout")).catch(() => "no timeout");
     const timeout = $fetch(getURL("timeout"), {


### PR DESCRIPTION
When a Request object is passed with an overriding method option, the generated FetchError should report the effective method option.

This changes the error message method precedence and adds coverage for the Request plus method override case.

Verification:
- pnpm vitest run test/index.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP method resolution to prioritize fetch options when both a request object and fetch options containing different methods are provided.

* **Tests**
  * Added test coverage to verify correct HTTP method precedence in error handling when multiple method specifications are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->