### PR TITLE
fix: improve isJSONSerializable safety and null handling

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function isJSONSerializable(value: any): boolean {
     return false;
   }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (value === null || t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {
@@ -28,12 +28,14 @@ export function isJSONSerializable(value: any): boolean {
   if (Array.isArray(value)) {
     return true;
   }
-  if (value.buffer) {
-    return false;
-  }
   // `FormData` and `URLSearchParams` should't have a `toJSON` method,
   // but Bun adds it, which is non-standard.
+  // Check these first to avoid potential errors from `value.buffer` access
+  // on certain edge cases.
   if (value instanceof FormData || value instanceof URLSearchParams) {
+    return false;
+  }
+  if (value.buffer) {
     return false;
   }
   return (


### PR DESCRIPTION
## Summary

- Move `instanceof` checks (FormData, URLSearchParams) before `value.buffer` to avoid potential errors from accessing `.buffer` on certain edge cases
- Fix null check: `typeof null` is `"object"`, not `null`, so the condition `t === null` was always false. This caused `null` to fall through to the `value.buffer` check, throwing a TypeError

## Changes

```ts
// Before (buggy)
if (t === 'string' || t === 'number' || t === 'boolean' || t === null) {  // t === null is always false!
  return true;
}
// ...
if (value.buffer) {  // null.buffer throws TypeError!
  return false;
}
if (value instanceof FormData || value instanceof URLSearchParams) {
  return false;
}

// After (fixed)
if (value === null || t === 'string' || t === 'number' || t === 'boolean') {
  return true;
}
// ...
if (value instanceof FormData || value instanceof URLSearchParams) {
  return false;
}
if (value.buffer) {
  return false;
}
```

## Verification

```js
isJSONSerializable(null)            // true  (was: TypeError)
isJSONSerializable(undefined)       // false ✓
isJSONSerializable(new FormData())  // false ✓
isJSONSerializable(new URLSearchParams()) // false ✓
isJSONSerializable(new Uint8Array()) // false ✓
```

All 28 existing tests pass.

Fixes #580
Fixes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null values and certain data types in serialization checks for better type detection accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->