### PR TITLE
fix: handle null and FormData order in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,12 +28,12 @@ export function isJSONSerializable(value: any): boolean {
   if (Array.isArray(value)) {
     return true;
   }
-  if (value.buffer) {
-    return false;
-  }
   // `FormData` and `URLSearchParams` should't have a `toJSON` method,
   // but Bun adds it, which is non-standard.
   if (value instanceof FormData || value instanceof URLSearchParams) {
+    return false;
+  }
+  if (value.buffer) {
     return false;
   }
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,11 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -525,3 +525,21 @@ describe("ofetch", () => {
     });
   });
 });
+
+describe("isJSONSerializable", () => {
+  let isJSONSerializable: (value: unknown) => boolean;
+
+  beforeAll(async () => {
+    const utils = await import("../src/utils.ts");
+    isJSONSerializable = utils.isJSONSerializable;
+  });
+
+  it("returns false for FormData and URLSearchParams before buffer checks", () => {
+    expect(isJSONSerializable(new FormData())).toBe(false);
+    expect(isJSONSerializable(new URLSearchParams())).toBe(false);
+
+    const data = new FormData();
+    data.append("foo", "bar");
+    expect(isJSONSerializable(data)).toBe(false);
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -542,4 +542,8 @@ describe("isJSONSerializable", () => {
     data.append("foo", "bar");
     expect(isJSONSerializable(data)).toBe(false);
   });
+
+  it("returns true for null without throwing", () => {
+    expect(isJSONSerializable(null)).toBe(true); // eslint-disable-line unicorn/no-null
+  });
 });


### PR DESCRIPTION
## Summary

- Return `true` for `null` via explicit check (`typeof null` is `"object"`)
- Check `FormData` / `URLSearchParams` before `value.buffer` to avoid throws on empty instances

## Example

```ts
isJSONSerializable(null); // true (no throw)
isJSONSerializable(new FormData()); // false
```

Fixes #571
Fixes #580

## Test plan

- [x] `pnpm test` passes
- [x] Added regression tests for `null` and FormData

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JSON serialization validation to properly handle null values and correctly process form-related objects.

* **Tests**
  * Added comprehensive test coverage for JSON serialization detection across null, FormData, and URLSearchParams inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->