### PR TITLE
fix(utils): move instanceof guards before value.buffer in isJSONSerializable (#580)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,12 +28,12 @@ export function isJSONSerializable(value: any): boolean {
   if (Array.isArray(value)) {
     return true;
   }
-  if (value.buffer) {
-    return false;
-  }
   // `FormData` and `URLSearchParams` should't have a `toJSON` method,
   // but Bun adds it, which is non-standard.
   if (value instanceof FormData || value instanceof URLSearchParams) {
+    return false;
+  }
+  if (value.buffer) {
     return false;
   }
   return (

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
 import { $fetch } from "../src/index.ts";
+import { isJSONSerializable } from "../src/utils.ts";
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;
@@ -523,5 +524,49 @@ describe("ofetch", () => {
       signal: expect.any(AbortSignal),
       timeout: 10_000,
     });
+  });
+});
+
+describe("isJSONSerializable", () => {
+  it("returns false for FormData (non-empty)", () => {
+    const fd = new FormData();
+    fd.append("key", "value");
+    expect(isJSONSerializable(fd)).toBe(false);
+  });
+
+  it("returns false for empty FormData", () => {
+    expect(isJSONSerializable(new FormData())).toBe(false);
+  });
+
+  it("returns false for URLSearchParams (non-empty)", () => {
+    expect(isJSONSerializable(new URLSearchParams({ foo: "bar" }))).toBe(false);
+  });
+
+  it("returns false for empty URLSearchParams", () => {
+    expect(isJSONSerializable(new URLSearchParams())).toBe(false);
+  });
+
+  it("returns false for ArrayBuffer", () => {
+    expect(isJSONSerializable(new ArrayBuffer(8))).toBe(false);
+  });
+
+  it("returns false for Uint8Array", () => {
+    expect(isJSONSerializable(new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it("returns true for plain objects", () => {
+    expect(isJSONSerializable({ a: 1 })).toBe(true);
+  });
+
+  it("returns true for arrays", () => {
+    expect(isJSONSerializable([1, 2, 3])).toBe(true);
+  });
+
+  it("returns true for objects with toJSON method", () => {
+    expect(isJSONSerializable({ toJSON: () => ({}) })).toBe(true);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isJSONSerializable(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `isJSONSerializable` checked `value.buffer` before `instanceof FormData || instanceof URLSearchParams`, making those guards unreachable for objects that expose a `.buffer` property
- In Bun, `FormData` has a non-standard `toJSON` method; if it exposes `buffer`, the explicit exclusion would silently fail
- Accessing `value.buffer` on certain host objects can also throw before reaching the instanceof checks

## Changes

- `src/utils.ts`: moved `instanceof FormData || instanceof URLSearchParams` before `value.buffer` check to ensure correct early rejection regardless of internal structure
- `test/index.test.ts`: added 10 unit tests for `isJSONSerializable` covering FormData, URLSearchParams, ArrayBuffer, TypedArray, plain objects, arrays, toJSON objects, and undefined

Fixes #580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for JSON-serialization validation, covering plain objects/arrays, objects with custom serialization, empty/non-empty form-like and binary inputs, and undefined.

* **Refactor**
  * Reordered internal validation checks for JSON-serializability to improve consistency without changing public behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ofetch/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->