### PR TITLE
fix(isJSONSerializable): move instanceof checks before value.buffer to prevent errors

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,12 +28,12 @@ export function isJSONSerializable(value: any): boolean {
   if (Array.isArray(value)) {
     return true;
   }
-  if (value.buffer) {
-    return false;
-  }
   // `FormData` and `URLSearchParams` should't have a `toJSON` method,
   // but Bun adds it, which is non-standard.
   if (value instanceof FormData || value instanceof URLSearchParams) {
+    return false;
+  }
+  if (value.buffer) {
     return false;
   }
   return (


### PR DESCRIPTION
## Summary

Moves `instanceof FormData` and `instanceof URLSearchParams` checks before the `value.buffer` check in `isJSONSerializable` to prevent potential errors from unsafe property access.

## Changes

- `src/utils.ts`: Reordered type checks — `instanceof` checks now run before `value.buffer` access

## Why

The `value.buffer` check on objects without a `buffer` property can throw in certain edge cases before the `instanceof` guards are reached. Since `FormData` and `URLSearchParams` instances are more specific conditions than "has a buffer", they should be checked first.

Closes #580