### PR TITLE
docs: document function form of retryDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ await ofetch("http://google.com/404", {
 });
 ```
 
+`retryDelay` can also be a function that receives the fetch context (with
+`request`, `options`, `response`, and `error`) and returns the delay in
+milliseconds. This lets you compute the delay dynamically — for example, to
+honor a server's `Retry-After` header:
+
+```ts
+await ofetch("/api", {
+  retry: 3,
+  retryDelay: (context) => {
+    const retryAfter = Number(context.response?.headers.get("retry-after"));
+    return Number.isFinite(retryAfter) ? retryAfter * 1000 : 500;
+  },
+});
+```
+
 ## ✔️ Timeout
 
 You can specify `timeout` in milliseconds to automatically abort a request after a timeout (default is disabled).


### PR DESCRIPTION
`retryDelay` can be a function `(context: FetchContext) => number`, supported since #372, but the **Auto Retry** section of the README only documents the numeric form.

This PR adds a short note that `retryDelay` can be a function receiving the fetch context, plus an example that honors a server's `Retry-After` response header.

Docs-only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring dynamic retry delays, showing how to provide a retry delay as a function that inspects the request/response context.
  * Included an example demonstrating how to derive retry timing from a server's Retry-After header to improve retry behavior and resiliency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->