### PR TITLE
fix(utils.url): delete existing key before appending array values in withQuery

### DIFF
--- a/src/utils.url.ts
+++ b/src/utils.url.ts
@@ -90,6 +90,7 @@ export function withQuery(input: string, query?: QueryObject): string {
     if (value === undefined) {
       searchParams.delete(key);
     } else if (Array.isArray(value)) {
+      searchParams.delete(key);
       for (const item of value) {
         searchParams.append(key, normalizeQueryValue(item));
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -344,6 +344,20 @@ describe("ofetch", () => {
     });
   });
 
+  it("replaces existing array query params instead of accumulating", async () => {
+    // When the URL already carries a value for a key and the query option
+    // supplies an array for that same key, the existing value should be
+    // replaced, not accumulated alongside the new ones. The /url/** endpoint
+    // echoes the raw path+search so we can inspect all repeated values.
+    const result = await $fetch(getURL("url/check?tag=old&other=1"), {
+      query: { tag: ["a", "b"] },
+    });
+    // "tag=old" must not appear; only "tag=a" and "tag=b" should be present
+    expect(result).toContain("tag=a");
+    expect(result).toContain("tag=b");
+    expect(result).not.toContain("tag=old");
+  });
+
   it("deep merges defaultOptions", async () => {
     const _customFetch = $fetch.create({
       query: {


### PR DESCRIPTION
When `withQuery` is called with a URL that already has a query string, scalar values are replaced correctly via `searchParams.set()`. Array values, though, were only appended without first removing the old entries for that key, so the original value leaked into the final URL alongside the new ones.

Example before this fix:

```ts
withQuery('https://example.org/path?tag=old&other=1', { tag: ['a', 'b'] })
// produced: ?tag=old&other=1&tag=a&tag=b  (tag=old should not be there)
```

After:

```ts
withQuery('https://example.org/path?tag=old&other=1', { tag: ['a', 'b'] })
// produces: ?other=1&tag=a&tag=b
```

The fix adds `searchParams.delete(key)` before the `append` loop, matching the replace semantics that `searchParams.set()` already provides for scalar values. A new test covers the case by fetching through the real h3 server and asserting the raw path+search echoed back.

All 29 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of undefined values in URL query parameters to ensure they are properly removed

* **Tests**
  * Added test coverage verifying that query parameters are correctly replaced rather than accumulated when provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->