### PR TITLE
fix(utils): handle null correctly in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,11 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
 import { $fetch } from "../src/index.ts";
+import { isJSONSerializable } from "../src/utils.ts";
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;
@@ -523,5 +524,50 @@ describe("ofetch", () => {
       signal: expect.any(AbortSignal),
       timeout: 10_000,
     });
+  });
+});
+
+describe("isJSONSerializable", () => {
+  it("returns true for null without throwing", () => {
+    expect(() => isJSONSerializable(null)).not.toThrow(); // eslint-disable-line unicorn/no-null
+    expect(isJSONSerializable(null)).toBe(true); // eslint-disable-line unicorn/no-null
+  });
+
+  it("returns false for undefined", () => {
+    expect(isJSONSerializable(undefined)).toBe(false);
+  });
+
+  it("returns true for primitives", () => {
+    expect(isJSONSerializable("hello")).toBe(true);
+    expect(isJSONSerializable(42)).toBe(true);
+    expect(isJSONSerializable(true)).toBe(true);
+    expect(isJSONSerializable(false)).toBe(true);
+  });
+
+  it("returns false for non-serializable types", () => {
+    expect(isJSONSerializable(() => {})).toBe(false);
+    expect(isJSONSerializable(Symbol("x"))).toBe(false);
+    expect(isJSONSerializable(42n)).toBe(false);
+  });
+
+  it("returns true for plain objects and arrays", () => {
+    expect(isJSONSerializable({})).toBe(true);
+    expect(isJSONSerializable({ a: 1 })).toBe(true);
+    expect(isJSONSerializable([])).toBe(true);
+    expect(isJSONSerializable([1, 2, 3])).toBe(true);
+  });
+
+  it("returns true for objects with toJSON", () => {
+    expect(isJSONSerializable({ toJSON: () => "{}" })).toBe(true);
+  });
+
+  it("returns false for Buffer and typed arrays", () => {
+    expect(isJSONSerializable(Buffer.from("hello"))).toBe(false);
+    expect(isJSONSerializable(new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it("returns false for FormData and URLSearchParams", () => {
+    expect(isJSONSerializable(new FormData())).toBe(false);
+    expect(isJSONSerializable(new URLSearchParams())).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #571

## What was wrong

`isJSONSerializable` in `src/utils.ts` had three bugs when called with `null`:

1. **Dead code** — `t === null` on line 22 (where `t = typeof value`) can never be true. `typeof` never returns the string `"null"`, so this branch was unreachable.
2. **Wrong return value** — `null` is valid JSON (`JSON.stringify(null) === "null"`), but the function never identified it as serializable.
3. **Runtime crash** — because `null` wasn't caught early, execution reached `value.buffer`, which throws `TypeError: Cannot read properties of null (reading 'buffer')`.

## Fix

Add an explicit `value === null` guard that returns `true` **before** any property access on `value`, and drop the dead `t === null` branch from the `typeof` check:

```ts
// Before (buggy)
const t = typeof value;
if (t === "string" || t === "number" || t === "boolean" || t === null) {
  return true;
}

// After
if (value === null) {
  return true;
}
const t = typeof value;
if (t === "string" || t === "number" || t === "boolean") {
  return true;
}
```

`undefined` and all other existing code paths are unaffected.

## Tests

Added a dedicated `describe("isJSONSerializable")` block in `test/index.test.ts` covering:

- `null` — does not throw, returns `true`
- `undefined` — returns `false`
- primitives (`string`, `number`, `boolean`) — return `true`
- non-serializable types (`function`, `symbol`, `bigint`) — return `false`
- plain objects and arrays — return `true`
- objects with `toJSON` — return `true`
- `Buffer` / `Uint8Array` — return `false`
- `FormData` / `URLSearchParams` — return `false`

The `null` test fails on the original code (`TypeError: Cannot read properties of null (reading 'buffer')`) and passes with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced null value handling in JSON serialization.

* **Tests**
  * Added comprehensive test coverage for JSON serialization, including null, undefined, primitives, and special object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->