### PR TITLE
fix: isJSONSerializable returns true for null (#571)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,11 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {

--- a/test/isjsonserializable.test.ts
+++ b/test/isjsonserializable.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isJSONSerializable } from "../src/utils.ts";
+
+describe("isJSONSerializable", () => {
+  it("returns true for null", () => {
+    expect(isJSONSerializable(null)).toBe(true);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isJSONSerializable(undefined)).toBe(false);
+  });
+
+  it("returns true for strings", () => {
+    expect(isJSONSerializable("hello")).toBe(true);
+  });
+
+  it("returns true for numbers", () => {
+    expect(isJSONSerializable(42)).toBe(true);
+    expect(isJSONSerializable(0)).toBe(true);
+    expect(isJSONSerializable(-1)).toBe(true);
+    expect(isJSONSerializable(3.14)).toBe(true);
+  });
+
+  it("returns true for booleans", () => {
+    expect(isJSONSerializable(true)).toBe(true);
+    expect(isJSONSerializable(false)).toBe(true);
+  });
+
+  it("returns true for arrays", () => {
+    expect(isJSONSerializable([])).toBe(true);
+    expect(isJSONSerializable([1, 2, 3])).toBe(true);
+    expect(isJSONSerializable([null, undefined])).toBe(true);
+  });
+
+  it("returns true for plain objects", () => {
+    expect(isJSONSerializable({})).toBe(true);
+    expect(isJSONSerializable({ a: 1 })).toBe(true);
+  });
+
+  it("returns false for buffers", () => {
+    expect(isJSONSerializable(new ArrayBuffer(8))).toBe(false);
+  });
+
+  it("returns false for FormData", () => {
+    expect(isJSONSerializable(new FormData())).toBe(false);
+  });
+
+  it("returns false for URLSearchParams", () => {
+    expect(isJSONSerializable(new URLSearchParams())).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #571

**Bug Description:**

The function had a critical bug on line 22 where it checked `t === null`,
but `typeof` never returns "null" (typeof null === "object").

This caused three issues:
1. Dead code: `t === null` was always false
2. `isJSONSerializable(null)` threw TypeError: "Cannot read properties of null (reading buffer)"
3. null was incorrectly identified as not JSON serializable

**Changes:**

- Added explicit `value === null` check before typeof comparison
- Removed `t === null` from typeof checks (impossible condition)

**Testing:**

- Added comprehensive unit tests (test/isjsonserializable.test.ts)
- Tests cover: null, undefined, strings, numbers, booleans, arrays, objects, FormData, URLSearchParams, buffers
- All 10 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug where null values were incorrectly handled during JSON serialization checks, causing improper processing in downstream operations.

* **Tests**
  * Added comprehensive test suite validating proper handling of null, undefined, primitives, arrays, objects, and various non-serializable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->