### PR TITLE
fix: add rss mime type to text types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,7 @@ export function isJSONSerializable(value: any): boolean {
 const textTypes = new Set([
   "image/svg",
   "application/xml",
+  "application/rss+xml",
   "application/xhtml",
   "application/html",
 ]);


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
resolves #597

Alternative would be to turn the set into a set of regexes and have `application\/([a-z]+\+)?xml` in it, which would be rss-agnostic. I'm not sure which mime types exist that are formed like this, maybe someone can help ☺️.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSS feed responses are now correctly recognized as text, improving how they’re handled and displayed instead of being treated as binary data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->