### PR TITLE
fix(utils): handle `null` in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,12 @@ export function isJSONSerializable(value: any): boolean {
   if (value === undefined) {
     return false;
   }
+  // `null` is JSON serializable (`JSON.stringify(null) === "null"`).
+  if (value === null) {
+    return true;
+  }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { isJSONSerializable } from "../src/utils.ts";
+
+describe("isJSONSerializable", () => {
+  it("treats primitives as serializable", () => {
+    expect(isJSONSerializable("foo")).toBe(true);
+    expect(isJSONSerializable(123)).toBe(true);
+    expect(isJSONSerializable(true)).toBe(true);
+  });
+
+  it("treats `null` as serializable without throwing", () => {
+    // Regression: previously this threw `Cannot read properties of null
+    // (reading 'buffer')` because `null` fell through to the `value.buffer`
+    // check. `JSON.stringify(null)` is valid (`"null"`).
+    // eslint-disable-next-line unicorn/no-null
+    expect(() => isJSONSerializable(null)).not.toThrow();
+    // eslint-disable-next-line unicorn/no-null
+    expect(isJSONSerializable(null)).toBe(true);
+  });
+
+  it("treats `undefined` as non-serializable", () => {
+    expect(isJSONSerializable(undefined)).toBe(false);
+  });
+
+  it("treats plain objects and arrays as serializable", () => {
+    expect(isJSONSerializable({ a: 1 })).toBe(true);
+    expect(isJSONSerializable([1, 2, 3])).toBe(true);
+  });
+
+  it("treats objects with a `toJSON` method as serializable", () => {
+    expect(isJSONSerializable(new Date())).toBe(true);
+  });
+
+  it("treats non-serializable values as non-serializable", () => {
+    expect(isJSONSerializable(() => {})).toBe(false);
+    expect(isJSONSerializable(Symbol("x"))).toBe(false);
+    expect(isJSONSerializable(10n)).toBe(false);
+    expect(isJSONSerializable(new Uint8Array([1, 2, 3]))).toBe(false);
+    expect(isJSONSerializable(new FormData())).toBe(false);
+    expect(isJSONSerializable(new URLSearchParams())).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`isJSONSerializable(null)` currently throws:

```
TypeError: Cannot read properties of null (reading 'buffer')
```

`null` falls through every early branch and reaches the `value.buffer` check (`src/utils.ts` line 31), where reading a property off `null` throws.

There is also a dead-code branch: `typeof value` can never return `null`, so the `t === null` part of the primitive check on line 22 never matches.

## Changes

- Add an explicit `value === null` early return. `null` **is** JSON serializable (`JSON.stringify(null) === "null"`), so it returns `true`.
- Remove the dead `t === null` condition from the primitive check.
- Add `test/utils.test.ts` with unit tests for `isJSONSerializable` covering `null`, `undefined`, primitives, plain objects, `toJSON` objects, arrays, and non-serializable values (functions, symbols, bigint, typed arrays, FormData, URLSearchParams).

## Validation

- `pnpm lint` passes (eslint + prettier).
- `vitest run` passes (34 tests, including the 6 new ones).
- Confirmed the new `null` test fails against the current code (reproduces the `TypeError`) and passes with this fix.

Closes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON serializability checks so `null` is now treated as serializable.
  * Improved handling of values that should not be considered JSON-safe, reducing incorrect results.

* **Tests**
  * Added coverage for serializable and non-serializable values.
  * Verified support for `null`, objects, arrays, and `toJSON`-based values, along with rejection of unsupported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->