### PR TITLE
fix: move instanceof checks before value.buffer in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,12 +28,12 @@ export function isJSONSerializable(value: any): boolean {
   if (Array.isArray(value)) {
     return true;
   }
-  if (value.buffer) {
-    return false;
-  }
   // `FormData` and `URLSearchParams` should't have a `toJSON` method,
   // but Bun adds it, which is non-standard.
   if (value instanceof FormData || value instanceof URLSearchParams) {
+    return false;
+  }
+  if (value.buffer) {
     return false;
   }
   return (


### PR DESCRIPTION
## Problem

In `isJSONSerializable()`, the `value.buffer` check (line 31) runs before the `instanceof FormData` / `instanceof URLSearchParams` checks. This can throw for certain edge cases where accessing `.buffer` on special objects causes errors.

## Fix

Move the `instanceof` checks before the `value.buffer` check to ensure safer type discrimination:

```diff
  if (Array.isArray(value)) {
    return true;
  }
+ // `FormData` and `URLSearchParams` should't have a `toJSON` method,
+ // but Bun adds it, which is non-standard.
+ if (value instanceof FormData || value instanceof URLSearchParams) {
+   return false;
+ }
  if (value.buffer) {
    return false;
  }
- // `FormData` and `URLSearchParams` should't have a `toJSON` method,
- // but Bun adds it, which is non-standard.
- if (value instanceof FormData || value instanceof URLSearchParams) {
-   return false;
- }
```

Fixes #580


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal validation checks to make serialization handling more consistent.
  * No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->