### PR TITLE
docs: fix license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,4 +385,4 @@ myFetch("/foo", { requiresAuth: true });
 
 ## License
 
-💛 Published under the [MIT](https://github.com/h3js/rou3/blob/main/LICENSE) license.
+💛 Published under the [MIT](https://github.com/unjs/ofetch/blob/main/LICENSE) license.


### PR DESCRIPTION
The README **License** section links to the wrong project's license file:

```markdown
💛 Published under the [MIT](https://github.com/h3js/rou3/blob/main/LICENSE) license.
```

`https://github.com/h3js/rou3/blob/main/LICENSE` is the LICENSE of the unrelated [`h3js/rou3`](https://github.com/h3js/rou3) URL-router project — most likely copy-paste drift from a shared UnJS template.

ofetch has its own MIT LICENSE at https://github.com/unjs/ofetch/blob/main/LICENSE, so this PR points the link there.

Docs-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the license reference in the README to point to the correct repository license file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->