### PR TITLE
fix: add application/rss+xml and application/*+xml to text response types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,7 @@ const textTypes = new Set([
   "application/xml",
   "application/xhtml",
   "application/html",
+  "application/rss+xml",
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,9 +47,6 @@ const textTypes = new Set([
   "application/xml",
   "application/xhtml",
   "application/html",
-  "application/rss+xml",
-  "application/atom+xml",
-  "application/xml-dtd",
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;
@@ -78,7 +75,8 @@ export function detectResponseType(_contentType = ""): ResponseType {
     return "stream";
   }
 
-  if (textTypes.has(contentType) || contentType.startsWith("text/")) {
+  // Handle text/*, application/*+xml, and known text types
+  if (textTypes.has(contentType) || contentType.startsWith("text/") || /^application\/.+\+xml$/.test(contentType)) {
     return "text";
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,8 @@ const textTypes = new Set([
   "application/xhtml",
   "application/html",
   "application/rss+xml",
+  "application/atom+xml",
+  "application/xml-dtd",
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;


### PR DESCRIPTION
### Problem

RSS feeds (and other xml subtypes) are returned as Blob instead of text because `application/rss+xml` is not in the text types set.

### Changes

1. Add `application/rss+xml`, `application/atom+xml`, and `application/xml-dtd` to known text types
2. Refactor to use regex pattern `application/*+xml` to catch all future xml subtypes automatically

Fixes #597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media type detection so additional XML-based content types are recognized as text.
  * This helps responses with XML-style structured suffixes display and handle correctly.
  * Existing JSON and streaming behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->