### PR TITLE
docs: document createFetch custom fetch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,29 @@ const apiFetch = ofetch.create({ baseURL: "/api" });
 apiFetch("/test"); // Same as ofetch('/test', { baseURL: '/api' })
 ```
 
+## 🔧 Using a custom fetch implementation
+
+You can use `createFetch` to create an `ofetch` instance backed by a custom `fetch` function. This is useful when you need a specific fetch implementation — for example, a Node.js-compatible fetch, a service worker's fetch, or a mock in tests.
+
+```js
+import { createFetch } from "ofetch";
+
+const myFetch = createFetch({ fetch: myCustomFetchImplementation });
+
+await myFetch("/api/users");
+```
+
+A common use case is providing `undici`'s fetch for full Node.js compatibility:
+
+```js
+import { createFetch } from "ofetch";
+import { fetch } from "undici";
+
+const nodeFetch = createFetch({ fetch });
+
+await nodeFetch("https://example.com/api");
+```
+
 ## 💡 Adding headers
 
 By using `headers` option, `ofetch` adds extra headers in addition to the request default headers:


### PR DESCRIPTION
## Summary

Fixes #533

The `createFetch` function accepts a `fetch` option in `CreateFetchOptions` that lets you provide a custom fetch implementation. This is useful for Node.js-compatible fetch (e.g. `undici`), service worker fetch, or test mocks — but it was completely undocumented in the README.

## Changes

- `README.md`: Added a new "🔧 Using a custom fetch implementation" section after "Create fetch with default options", showing how to use `createFetch({ fetch: customImpl })` with a basic example and a practical `undici` example.

## Test plan
- [ ] README renders correctly on GitHub and npmjs.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using a custom fetch implementation when creating an `ofetch` instance.
  * Included examples for passing a custom `fetch` function and using `undici`’s `fetch` in Node.js.
  * Expanded the setup docs with this new option alongside the default configuration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->