### PR TITLE
fix: normalize `headers` reassigned in an `onRequest` hook

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -109,6 +109,12 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
     if (context.options.onRequest) {
       await callHooks(context, context.options.onRequest);
+      // A hook may reassign `headers` to a plain object or array (a valid
+      // `HeadersInit`), so normalize it back to a `Headers` instance before the
+      // code below calls `.get()`/`.set()`/`.has()` on it.
+      if (!(context.options.headers instanceof Headers)) {
+        context.options.headers = new Headers(context.options.headers || {});
+      }
     }
 
     if (typeof context.request === "string") {
@@ -143,8 +149,6 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
         // Set Content-Type and Accept headers to application/json by default
         // for JSON serializable request bodies.
-        // Pass empty object as older browsers don't support undefined.
-        context.options.headers = new Headers(context.options.headers || {});
         if (!contentType) {
           context.options.headers.set("content-type", "application/json");
         }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -397,6 +397,32 @@ describe("ofetch", () => {
     ).toMatchObject({ foo: "2", bar: "3" });
   });
 
+  it("normalizes headers reassigned in onRequest hook", async () => {
+    // A `Headers` instance reassigned in the hook is sent as-is.
+    expect(
+      await $fetch(getURL("/echo"), {
+        method: "POST",
+        body: { num: 42 },
+        onRequest(ctx) {
+          ctx.options.headers = new Headers({ "x-foo": "bar" });
+        },
+      }).then((r) => r.headers)
+    ).toMatchObject({ "x-foo": "bar" });
+
+    // A plain object reassigned in the hook is normalized back to `Headers`
+    // instead of throwing `headers.get is not a function` before the request.
+    expect(
+      await $fetch(getURL("/echo"), {
+        method: "POST",
+        body: { num: 42 },
+        onRequest(ctx) {
+          // @ts-expect-error backwards compatibility for object headers
+          ctx.options.headers = { "x-foo": "bar" };
+        },
+      }).then((r) => r.headers)
+    ).toMatchObject({ "x-foo": "bar" });
+  });
+
   it("hook errors", async () => {
     // onRequest
     await expect(


### PR DESCRIPTION
`resolveFetchOptions` returns `options.headers` as a `Headers` instance, but an `onRequest` hook can reassign it to a plain object (a valid `HeadersInit`). In v2 the request flow reads `context.options.headers.get("content-type")` immediately after the hook runs, so reassigning a plain object throws `TypeError: context.options.headers.get is not a function` on any payload request with a JSON-serializable body.

This was already handled on v1 in #524 (and #436 before it), but the v2 rewrite reintroduced it. The normalization now lives inside the JSON-body branch and runs after that first `.get()` call, so it never gets a chance to run.

Repro:

```js
await $fetch("/api", {
  method: "POST",
  body: { hello: "world" },
  onRequest(ctx) {
    ctx.options.headers = { "x-foo": "bar" }; // throws before this fix
  },
});
```

The fix mirrors #524: re-normalize `options.headers` back to a `Headers` instance right after the `onRequest` hook, and drop the now-redundant re-creation in the body branch (`resolveFetchOptions` already returns a fresh `Headers`, so the later `.set()` calls can mutate it directly).

Added a regression test covering both a `Headers` instance and a plain object reassigned in the hook, matching the v1 test. The new test fails without the change (`headers.get is not a function`) and passes with it. Full suite (29) is green and `eslint` / `prettier` / `tsc --noEmit` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request header handling so headers remain safe to read and update after request hooks modify them.
  * Fixed an issue where reassigned headers could cause inconsistent request behavior when using different header formats.
* **Tests**
  * Added coverage for header reassignment scenarios to confirm requests still send the expected headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->