### PR TITLE
fix(fetch): retry network errors regardless of retryStatusCodes

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -54,12 +54,18 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         retries = isPayloadMethod(context.options.method) ? 0 : 1;
       }
 
-      const responseCode = (context.response && context.response.status) || 500;
+      // When there is no response (network / connection error), bypass the
+      // status code check and always retry. Previously the code fell back to
+      // 500, which caused requests to silently stop being retried whenever
+      // callers supplied a custom retryStatusCodes array that excluded 500.
+      const hasResponse = !!(context.response && context.response.status);
+      const responseCode = hasResponse ? context.response!.status : undefined;
       if (
         retries > 0 &&
-        (Array.isArray(context.options.retryStatusCodes)
-          ? context.options.retryStatusCodes.includes(responseCode)
-          : retryStatusCodes.has(responseCode))
+        (!hasResponse ||
+          (Array.isArray(context.options.retryStatusCodes)
+            ? context.options.retryStatusCodes.includes(responseCode!)
+            : retryStatusCodes.has(responseCode!)))
       ) {
         const retryDelay =
           typeof context.options.retryDelay === "function"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -309,6 +309,33 @@ describe("ofetch", () => {
     await expect(abortHandle()).rejects.toThrow(/aborted/);
   });
 
+  it("network errors are retried even when retryStatusCodes excludes 500", async () => {
+    // Simulate a network-level failure (no HTTP response at all).
+    // Previously, ofetch fell back to status code 500 when context.response
+    // was undefined. A custom retryStatusCodes array that excluded 500 would
+    // therefore also suppress retries for connection errors.
+    let callCount = 0;
+    const networkError = new TypeError("Failed to fetch");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      callCount++;
+      throw networkError;
+    };
+    try {
+      await $fetch("https://example.com", {
+        retry: 2,
+        // 500 is intentionally absent; only proxy-related codes are listed.
+        retryStatusCodes: [502, 503, 504],
+      });
+    } catch {
+      // expected to throw after exhausting retries
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    // Initial attempt + 2 retries = 3 calls total.
+    expect(callCount).toBe(3);
+  });
+
   it("passing request obj should return request obj in error", async () => {
     const error = await $fetch(getURL("/403"), { method: "post" }).catch(
       (error: any) => error


### PR DESCRIPTION
## Bug

Closes #495.

When a request fails at the network level (no HTTP response is produced at all — e.g. a connection refused, DNS failure, or fetch abort via timeout), `onError` fell back to status code `500` as a sentinel:

```ts
// src/fetch.ts (before)
const responseCode = (context.response && context.response.status) || 500;
```

Because the default `retryStatusCodes` set includes `500`, this worked fine out of the box. But callers who provided a custom `retryStatusCodes` array that deliberately excluded `500` (a reasonable choice: re-sending a POST on a 500 can cause duplicate side-effects on the server) would unknowingly also stop retrying pure connection errors that never returned any response at all. The two failure modes are conflated by the `|| 500` fallback.

## Fix

When `context.response` is absent, skip the status-code gate entirely and allow the retry based solely on the remaining retry count. The `retryStatusCodes` option is only meaningful when the server actually returned an HTTP response.

```ts
// src/fetch.ts (after)
const hasResponse = !!(context.response && context.response.status);
const responseCode = hasResponse ? context.response!.status : undefined;
if (
  retries > 0 &&
  (!hasResponse ||
    (Array.isArray(context.options.retryStatusCodes)
      ? context.options.retryStatusCodes.includes(responseCode!)
      : retryStatusCodes.has(responseCode!)))
) {
```

## Reproduction

```ts
// Before fix: only 1 call (no retries) because 500 is absent from the list
// After fix:  3 calls (initial + 2 retries) as expected
await $fetch("https://unreachable-host.example", {
  retry: 2,
  retryStatusCodes: [502, 503, 504], // 500 intentionally excluded
});
```

## Test

A new test in `test/index.test.ts` stubs `globalThis.fetch` to throw a `TypeError` (simulating a network error), then asserts that `ofetch` still performs the expected number of retry attempts when `retryStatusCodes` excludes `500`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for failed requests when no response is returned, so network or connection errors now continue retrying as expected.
  * Retry settings based on HTTP status codes now apply only when a status code is actually available, preventing unexpected stops on connection failures.
* **Tests**
  * Added coverage for retries on network-level failures to verify the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->