### PR TITLE
fix: treat null as JSON-serializable in isJSONSerializable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function isJSONSerializable(value: any): boolean {
     return false;
   }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (value === null || t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
 import { $fetch } from "../src/index.ts";
+import { isJSONSerializable } from "../src/utils.ts";
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;
@@ -523,5 +524,26 @@ describe("ofetch", () => {
       signal: expect.any(AbortSignal),
       timeout: 10_000,
     });
+  });
+});
+
+describe("isJSONSerializable", () => {
+  it("treats null as serializable without throwing", () => {
+    // `typeof null` is "object", so the old `t === null` check was dead code
+    // and execution fell through to `value.buffer`, throwing on null.
+    // eslint-disable-next-line unicorn/no-null
+    const value = null;
+    expect(() => isJSONSerializable(value)).not.toThrow();
+    expect(isJSONSerializable(value)).toBe(true);
+  });
+
+  it("classifies common values", () => {
+    expect(isJSONSerializable(undefined)).toBe(false);
+    expect(isJSONSerializable("str")).toBe(true);
+    expect(isJSONSerializable(1)).toBe(true);
+    expect(isJSONSerializable({ a: 1 })).toBe(true);
+    expect(isJSONSerializable([1, 2])).toBe(true);
+    expect(isJSONSerializable(new Uint8Array())).toBe(false);
+    expect(isJSONSerializable(() => {})).toBe(false);
   });
 });


### PR DESCRIPTION
Since `typeof null` is `"object"`, the `t === null` branch in `isJSONSerializable` was dead code (`t` is always a string). As a result `isJSONSerializable(null)` fell through to the `value.buffer` access and threw `TypeError: Cannot read properties of null (reading 'buffer')`.

`null` is JSON-serializable (`JSON.stringify(null) === "null"`), so this checks `value === null` up front and returns `true`, which also removes the dead check.

No behavior change for `$fetch` itself — a `null` body is already short-circuited by the `context.options.body &&` guard before this util is reached; the fix matters for direct/library use of the exported helper.

Resolves #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `null` values so they are now correctly recognized as JSON-serializable.
  * Expanded validation to better distinguish serializable values from unsupported types like `undefined`, functions, and typed arrays.

* **Tests**
  * Added coverage for JSON-serializability checks across common primitives, objects, arrays, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->