### PR TITLE
chore: fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ setGlobalDispatcher(new ProxyAgent("http://localhost:3128"));
 ```ts
 import { Agent } from "undici";
 
-// Note: This makes fetch unsecure against MITM attacks. USE AT YOUR OWN RISK!
+// Note: This makes fetch insecure against MITM attacks. USE AT YOUR OWN RISK!
 const unsecureAgent = new Agent({ connect: { rejectUnauthorized: false } });
 await ofetch("https://self-signed.example.com/", { dispatcher: unsecureAgent });
 ```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,7 @@ export function isJSONSerializable(value: any): boolean {
   if (value.buffer) {
     return false;
   }
-  // `FormData` and `URLSearchParams` should't have a `toJSON` method,
+  // `FormData` and `URLSearchParams` shouldn't have a `toJSON` method,
   // but Bun adds it, which is non-standard.
   if (value instanceof FormData || value instanceof URLSearchParams) {
     return false;


### PR DESCRIPTION
Two small typos in comments:

- `README.md` line 339: `unsecure` → `insecure` (the correct English adjective meaning "not secure"; "unsecure" is non-standard)
- `src/utils.ts` line 34: `should't` → `shouldn't` (missing apostrophe in contraction)

Both found with codespell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected wording in a security warning about self-signed certificates.
* **Style**
  * Fixed a typo in an inline comment about JSON serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->