### PR TITLE
docs: document custom fetch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,36 @@ const apiFetch = ofetch.create({ baseURL: "/api" });
 apiFetch("/test"); // Same as ofetch('/test', { baseURL: '/api' })
 ```
 
+## ✔️ Custom `fetch` implementation
+
+`ofetch` calls the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) under the hood. By default it uses `globalThis.fetch`, but you can provide your own implementation when creating an instance.
+
+This is useful for tests (mocking requests), forcing a specific runtime implementation (for example [undici](https://undici.nodejs.org/) in Node.js), or environments where you need a custom `fetch` wrapper.
+
+Pass `fetch` to `createFetch` or as the second argument of `ofetch.create`:
+
+```ts
+import { createFetch } from "ofetch";
+
+const $fetch = createFetch({
+  fetch: myCustomFetch,
+  defaults: {
+    baseURL: "/api",
+  },
+});
+```
+
+```ts
+import { ofetch } from "ofetch";
+
+const apiFetch = ofetch.create(
+  { baseURL: "/api" },
+  { fetch: myCustomFetch }
+);
+```
+
+The custom `fetch` must match the standard `fetch(input, init?)` signature. All `ofetch` features (JSON body handling, retries, hooks, and so on) still run on top of it.
+
 ## 💡 Adding headers
 
 By using `headers` option, `ofetch` adds extra headers in addition to the request default headers:


### PR DESCRIPTION
## Summary

Closes #533.

Documents the `fetch` option for `createFetch` and `ofetch.create`, which lets callers plug in a custom Fetch API implementation.

## Test plan

- [x] Verified against `src/fetch.ts` and `CreateFetchOptions` in `src/types.ts`
- [x] README-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring a custom `fetch` implementation.
  - Included examples using supported configuration methods.
  - Documented the required standard `fetch(input, init?)` signature and compatibility with existing features such as retries, hooks, and JSON body handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->