### PR TITLE
fix(utils.url): keep the hash out of the query in `withQuery`

### DIFF
--- a/src/utils.url.ts
+++ b/src/utils.url.ts
@@ -66,6 +66,15 @@ export function withQuery(input: string, query?: QueryObject): string {
     return input;
   }
 
+  // The fragment always comes last (RFC 3986), so split it off before
+  // touching the query and re-append it at the end.
+  const hashIndex = input.indexOf("#");
+  let hash = "";
+  if (hashIndex !== -1) {
+    hash = input.slice(hashIndex);
+    input = input.slice(0, hashIndex);
+  }
+
   const searchIndex = input.indexOf("?");
 
   if (searchIndex === -1) {
@@ -80,7 +89,7 @@ export function withQuery(input: string, query?: QueryObject): string {
       });
     const searchParams = new URLSearchParams(normalizedQuery);
     const queryString = searchParams.toString();
-    return queryString ? `${input}?${queryString}` : input;
+    return queryString ? `${input}?${queryString}${hash}` : `${input}${hash}`;
   }
 
   const searchParams = new URLSearchParams(input.slice(searchIndex + 1));
@@ -99,7 +108,7 @@ export function withQuery(input: string, query?: QueryObject): string {
   }
 
   const queryString = searchParams.toString();
-  return queryString ? `${base}?${queryString}` : base;
+  return queryString ? `${base}?${queryString}${hash}` : `${base}${hash}`;
 }
 
 function normalizeQueryValue(value: QueryValue): string {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -382,6 +382,30 @@ describe("ofetch", () => {
     expect(parseParams(path)).toMatchObject({ a: "1", b: "2", c: "3" });
   });
 
+  it("keeps the hash out of the query", async () => {
+    // The hash is always last, so query params have to be inserted before it.
+    expect(
+      await $fetch(getURL("echo#hash"), { query: { foo: "1" } }).then(
+        (r) => r.path
+      )
+    ).to.equal("/echo?foo=1");
+
+    expect(
+      await $fetch(getURL("echo?a=1#hash"), { query: { b: "2" } }).then(
+        (r) => r.path
+      )
+    ).to.equal("/echo?a=1&b=2");
+
+    let requestURL: string | undefined;
+    await $fetch(getURL("echo#hash"), {
+      query: { foo: "1" },
+      onResponse({ request }) {
+        requestURL = request as string;
+      },
+    });
+    expect(requestURL).to.equal(getURL("echo") + "?foo=1#hash");
+  });
+
   it("uses request headers", async () => {
     expect(
       await $fetch(


### PR DESCRIPTION
`withQuery` treats the whole input as `path[?query]`, so a URL that carries a fragment ends up mangled. The hash is the last component of a URL, so the query has to be spliced in before it.

There are two failure modes, both reachable through `$fetch` since `fetch.ts` calls `withQuery(context.request, context.options.query)` for any string request:

When the URL has no `?`, the added parameters are appended after the `#` and become part of the fragment, so they are never sent. When the URL already has a `?`, everything after it (including the fragment) is parsed as the query string, so the last existing parameter's value silently absorbs `#section` as `%23section`.

This is a regression against v1, which used `ufo`'s `withQuery`. Minimal reproduction against the published packages:

```js
import { createServer } from "node:http";
import { $fetch } from "ofetch";            // 2.0.0-alpha.3
import { $fetch as $fetch1 } from "ofetch1"; // 1.5.1

const server = createServer((req, res) => {
  res.setHeader("content-type", "application/json");
  res.end(JSON.stringify({ seen: req.url }));
}).listen(0);
const base = `http://localhost:${server.address().port}`;

console.log(await $fetch(`${base}/api#section`, { query: { foo: "1" } }));
console.log(await $fetch1(`${base}/api#section`, { query: { foo: "1" } }));
console.log(await $fetch(`${base}/api?a=1#section`, { query: { b: "2" } }));
console.log(await $fetch1(`${base}/api?a=1#section`, { query: { b: "2" } }));

server.close();
```

```
2.0.0-alpha.3: { seen: '/api' }              <- foo=1 lost
1.5.1        : { seen: '/api?foo=1' }
2.0.0-alpha.3: { seen: '/api?a=1%23section&b=2' } <- a corrupted
1.5.1        : { seen: '/api?a=1&b=2' }
```

The fix splits the fragment off before touching the query and re-appends it at the end. I checked the patched `withQuery` against `ufo@1.6.4` over the hash edge cases (no hash, empty hash, hash before/after an existing query, hash-only input, query that resolves to empty) and the output matches.

The regression test goes through the existing `/echo` route, which reports `pathname + search`, so it asserts what the server actually receives rather than what the helper returns; the last assertion uses an `onResponse` hook to check that the fragment itself survives in the final request URL. It fails on `main` with `expected '/echo' to equal '/echo?foo=1'`.

`pnpm lint` and `vitest run` both pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved URL hash fragments when adding, updating, or removing query parameters.
  * Ensured query parameters are placed before the fragment, maintaining correct request URLs.

* **Tests**
  * Added coverage for query handling on URLs with hash fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->