### PR TITLE
Detect XML structured suffix response types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,7 @@ const textTypes = new Set([
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;
+const XML_RE = /^(?:application|image)\/(?:[\w!#$%&*.^`~-]+\+)?xml$/i;
 
 // This provides reasonable defaults for the correct parser based on Content-Type header.
 export function detectResponseType(_contentType = ""): ResponseType {
@@ -75,7 +76,11 @@ export function detectResponseType(_contentType = ""): ResponseType {
     return "stream";
   }
 
-  if (textTypes.has(contentType) || contentType.startsWith("text/")) {
+  if (
+    XML_RE.test(contentType) ||
+    textTypes.has(contentType) ||
+    contentType.startsWith("text/")
+  ) {
     return "text";
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,28 @@ import {
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
 import { $fetch } from "../src/index.ts";
+import { detectResponseType } from "../src/utils.ts";
+
+describe("detectResponseType", () => {
+  it.each([
+    "application/xml",
+    "application/rss+xml",
+    "application/atom+xml",
+    "application/xhtml+xml",
+    "image/svg+xml",
+    "text/xml",
+    "application/soap+xml; charset=utf-8",
+    "APPLICATION/RSS+XML",
+  ])("detects %s as text", (contentType) => {
+    expect(detectResponseType(contentType)).to.equal("text");
+  });
+
+  it("preserves other response type detection", () => {
+    expect(detectResponseType("application/octet-stream")).to.equal("blob");
+    expect(detectResponseType("application/ld+json")).to.equal("json");
+    expect(detectResponseType("text/event-stream")).to.equal("stream");
+  });
+});
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;


### PR DESCRIPTION
Fixes #597.

`detectResponseType` only recognized a small set of exact XML media types. Structured syntax suffix types such as `application/rss+xml`, `application/atom+xml`, `application/xhtml+xml`, and `image/svg+xml` therefore fell through to `blob` instead of being decoded as text.

This adds XML media-type detection for `application/*+xml` and `image/*+xml`, while retaining the existing `text/*` handling. Tests cover RSS, Atom, XHTML, SVG, SOAP with parameters, case-insensitive headers, and regression guards for JSON, SSE, and binary content.

Validation:
- `vitest run --coverage` — 35 passed before final edge-case additions
- targeted `vitest run test/index.test.ts` — 37 passed
- ESLint and Prettier checks passed for both changed files

The repository-wide Prettier command reports pre-existing formatting differences in 16 untouched files on this Windows checkout; all changed files pass the same checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling for XML-based content types, including RSS, Atom, and vendor-specific XML formats.
  * Preserved existing handling for JSON, binary, and streaming responses.

* **Tests**
  * Added coverage to verify XML content is correctly treated as text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->