### PR TITLE
fix: give each retry its own timeout window

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ await ofetch("http://google.com/404", {
 });
 ```
 
+When combined with auto retry, each attempt gets its own fresh `timeout` window.
+
 ## ✔️ Type Friendly
 
 The response can be type assisted:

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -168,20 +168,23 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
     let abortTimeout: NodeJS.Timeout | undefined;
 
+    // Derive a fresh timeout signal for each attempt without persisting it on
+    // `context.options.signal`. Otherwise a retry triggered by a timeout would
+    // reuse the already aborted signal and abort immediately instead of getting
+    // its own timeout window.
+    let fetchOptions = context.options as RequestInit;
     if (context.options.timeout) {
-      context.options.signal = context.options.signal
-        ? AbortSignal.any([
-            AbortSignal.timeout(context.options.timeout),
-            context.options.signal,
-          ])
-        : AbortSignal.timeout(context.options.timeout);
+      const timeoutSignal = AbortSignal.timeout(context.options.timeout);
+      fetchOptions = {
+        ...context.options,
+        signal: context.options.signal
+          ? AbortSignal.any([timeoutSignal, context.options.signal])
+          : timeoutSignal,
+      } as RequestInit;
     }
 
     try {
-      context.response = await fetch(
-        context.request,
-        context.options as RequestInit
-      );
+      context.response = await fetch(context.request, fetchOptions);
     } catch (error) {
       context.error = error as Error;
       if (context.options.onRequestError) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,6 +18,8 @@ describe("ofetch", () => {
 
   const fetch = vi.spyOn(globalThis, "fetch");
 
+  let timeoutThenOkCount = 0;
+
   beforeAll(async () => {
     const app = new H3({ debug: true })
       // .use(async (event) => {
@@ -62,6 +64,14 @@ describe("ofetch", () => {
             resolve(new HTTPError({ status: 408 }));
           }, 1000 * 5);
         });
+      })
+      .all("/timeout-then-ok", async () => {
+        timeoutThenOkCount++;
+        // Slow enough to trip a short timeout only on the first attempt.
+        if (timeoutThenOkCount === 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000 * 5));
+        }
+        return "ok";
       });
 
     listener = await serve(app, { port: 0, hostname: "localhost" }).ready();
@@ -342,6 +352,18 @@ describe("ofetch", () => {
       expect(error.cause.name).to.equal("TimeoutError");
       expect(error.cause.code).to.equal(DOMException.TIMEOUT_ERR);
     });
+  });
+
+  it("retry after a timeout uses a fresh timeout for each attempt", async () => {
+    timeoutThenOkCount = 0;
+    // The first attempt times out; the retry must get its own timeout window
+    // (not reuse the already aborted signal) so it can succeed.
+    const result = await $fetch(getURL("timeout-then-ok"), {
+      timeout: 100,
+      retry: 2,
+    });
+    expect(result).to.equal("ok");
+    expect(timeoutThenOkCount).toBeGreaterThanOrEqual(2);
   });
 
   it("deep merges defaultOptions", async () => {


### PR DESCRIPTION
When `timeout` is set, the timeout signal was assigned onto `context.options.signal`, which `onError` spreads into the retry request. Once a timeout aborts that signal, every subsequent retry reused the already-aborted signal and aborted immediately, so `retry` was effectively a no-op whenever `timeout` was set.

This derives the per-attempt timeout signal into the options passed to `fetch` without persisting it on `context.options`, so each retry gets a fresh timeout window.

Repro (before): a server that always delays 300ms; `ofetch(url, { timeout: 100, retry: 3 })` fires its retries at ~0/104/105/105ms (total ~105ms) instead of ~100ms apart. After: ~0/104/207/311ms.

Regression test added (a request slow only on the first attempt now succeeds via a retry). Existing timeout tests all used `retry: 0`, so this interaction was never covered. Docs note added to the Timeout section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic retries failing prematurely after a timeout.
  * Each retry now receives a fresh timeout window, allowing delayed requests to complete successfully.

* **Documentation**
  * Clarified timeout behavior when automatic retries are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->