### PR TITLE
fix: keep timeout active until response body is consumed

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -197,6 +197,9 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       );
     } catch (error) {
       context.error = error as Error;
+      if (abortTimeout) {
+        clearTimeout(abortTimeout);
+      }
       if (context.options.onRequestError) {
         await callHooks(
           context as FetchContext & { error: Error },
@@ -204,68 +207,79 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         );
       }
       return await onError(context);
+    }
+
+    // Keep the timeout armed until the body is consumed. Clearing it in the
+    // fetch() finally (headers received) left incomplete bodies hanging forever.
+    // https://github.com/unjs/ofetch/issues/620
+    try {
+      const hasBody =
+        (context.response.body ||
+          // https://github.com/unjs/ofetch/issues/324
+          // https://github.com/unjs/ofetch/issues/294
+          // https://github.com/JakeChampion/fetch/issues/1454
+          (context.response as any)._bodyInit) &&
+        !nullBodyResponses.has(context.response.status) &&
+        context.options.method !== "HEAD";
+      if (hasBody) {
+        const responseType =
+          (context.options.parseResponse
+            ? "json"
+            : context.options.responseType) ||
+          detectResponseType(context.response.headers.get("content-type") || "");
+
+        // We override the `.json()` method to parse the body more securely with `destr`
+        switch (responseType) {
+          case "json": {
+            const data = await context.response.text();
+            const parseFunction = context.options.parseResponse || destr;
+            context.response._data = parseFunction(data);
+            break;
+          }
+          case "stream": {
+            context.response._data =
+              context.response.body || (context.response as any)._bodyInit; // (see refs above)
+            break;
+          }
+          default: {
+            context.response._data = await context.response[responseType]();
+          }
+        }
+      }
+
+      if (context.options.onResponse) {
+        await callHooks(
+          context as FetchContext & { response: FetchResponse<any> },
+          context.options.onResponse
+        );
+      }
+
+      if (
+        !context.options.ignoreResponseError &&
+        context.response.status >= 400 &&
+        context.response.status < 600
+      ) {
+        if (context.options.onResponseError) {
+          await callHooks(
+            context as FetchContext & { response: FetchResponse<any> },
+            context.options.onResponseError
+          );
+        }
+        return await onError(context);
+      }
+
+      return context.response;
+    } catch (error) {
+      if (context.options.signal?.aborted) {
+        context.error = error as Error;
+        return await onError(context);
+      }
+      throw error;
     } finally {
       if (abortTimeout) {
         clearTimeout(abortTimeout);
       }
     }
-
-    const hasBody =
-      (context.response.body ||
-        // https://github.com/unjs/ofetch/issues/324
-        // https://github.com/unjs/ofetch/issues/294
-        // https://github.com/JakeChampion/fetch/issues/1454
-        (context.response as any)._bodyInit) &&
-      !nullBodyResponses.has(context.response.status) &&
-      context.options.method !== "HEAD";
-    if (hasBody) {
-      const responseType =
-        (context.options.parseResponse
-          ? "json"
-          : context.options.responseType) ||
-        detectResponseType(context.response.headers.get("content-type") || "");
-
-      // We override the `.json()` method to parse the body more securely with `destr`
-      switch (responseType) {
-        case "json": {
-          const data = await context.response.text();
-          const parseFunction = context.options.parseResponse || destr;
-          context.response._data = parseFunction(data);
-          break;
-        }
-        case "stream": {
-          context.response._data =
-            context.response.body || (context.response as any)._bodyInit; // (see refs above)
-          break;
-        }
-        default: {
-          context.response._data = await context.response[responseType]();
-        }
-      }
-    }
-
-    if (context.options.onResponse) {
-      await callHooks(
-        context as FetchContext & { response: FetchResponse<any> },
-        context.options.onResponse
-      );
-    }
-
-    if (
-      !context.options.ignoreResponseError &&
-      context.response.status >= 400 &&
-      context.response.status < 600
-    ) {
-      if (context.options.onResponseError) {
-        await callHooks(
-          context as FetchContext & { response: FetchResponse<any> },
-          context.options.onResponseError
-        );
-      }
-      return await onError(context);
-    }
-
-    return context.response;
   };
 
   const $fetch = async function $fetch(request, options) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,6 +90,16 @@ describe("ofetch", () => {
             }, 1000 * 5);
           });
         })
+      )
+      .use(
+        "/slow-body",
+        eventHandler(async (event) => {
+          event.node.res.writeHead(200, {
+            "content-type": "text/plain; charset=utf-8",
+          });
+          event.node.res.write("partial");
+          await new Promise(() => {});
+        })
       );
 
     listener = await listen(toNodeListener(app));
@@ -375,6 +385,18 @@ describe("ofetch", () => {
       expect(error.cause.name).to.equal("TimeoutError");
       expect(error.cause.code).to.equal(DOMException.TIMEOUT_ERR);
     });
+  });
+
+  it("aborts when response body does not finish before timeout", async () => {
+    const start = Date.now();
+    await expect(
+      $fetch(getURL("slow-body"), {
+        timeout: 150,
+        retry: 0,
+        responseType: "text",
+      })
+    ).rejects.toBeDefined();
+    expect(Date.now() - start).toBeLessThan(1500);
   });
 
   it("deep merges defaultOptions", async () => {


### PR DESCRIPTION
## Summary

- `timeout` only covered the time until response **headers** arrived. The abort timer was `clearTimeout`'d in the `fetch()` `finally`, so an incomplete body (server writes some bytes and never `end()`s) hung forever.
- Keep the timer armed through body parse. If the signal aborts while reading the body, surface it as a `FetchError` like a request-phase timeout.
- Adds a regression test (`/slow-body`) that sends headers + a partial body and never finishes.

Fixes #620

## Test plan

- [x] `vitest run` — 30/30 pass, including:
  - existing `aborting on timeout` / `aborting on timeout reason`
  - new `aborts when response body does not finish before timeout`
- [ ] Repro from https://github.com/dword-design/demo-ofetch-response-body-timeout should reject within `timeout` instead of hanging