### PR TITLE
feat: support HTTP QUERY method (RFC 10008) as payload method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If an object or a class with a `.toJSON()` method is passed to the `body` option
 
 `ofetch` utilizes `JSON.stringify()` to convert the passed object. Classes without a `.toJSON()` method have to be converted into a string value in advance before being passed to the `body` option.
 
-For `PUT`, `PATCH`, and `POST` request methods, when a string or object body is set, `ofetch` adds the default `"content-type": "application/json"` and `accept: "application/json"` headers (which you can always override).
+For `PUT`, `PATCH`, `POST`, `DELETE`, and `QUERY` request methods, when a string or object body is set, `ofetch` adds the default `"content-type": "application/json"` and `accept: "application/json"` headers (which you can always override).
 
 Additionally, `ofetch` supports binary responses with `Buffer`, `ReadableStream`, `Stream`, and [compatible body types](https://developer.mozilla.org/en-US/docs/Web/API/fetch#body). `ofetch` will automatically set the `duplex: "half"` option for streaming support!
 
@@ -114,7 +114,7 @@ await ofetch("/url", { ignoreResponseError: true });
 
 You can specify the amount of retry and delay between them using `retry` and `retryDelay` options and also pass a custom array of codes using `retryStatusCodes` option.
 
-The default for `retry` is `1` retry, except for `POST`, `PUT`, `PATCH`, and `DELETE` methods where `ofetch` does not retry by default to avoid introducing side effects. If you set a custom value for `retry` it will **always retry** for all requests.
+The default for `retry` is `1` retry, except for `POST`, `PUT`, `PATCH`, `DELETE`, and `QUERY` methods where `ofetch` does not retry by default to avoid introducing side effects. If you set a custom value for `retry` it will **always retry** for all requests.
 
 The default for `retryDelay` is `0` ms.
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import type {
 } from "./types.ts";
 
 const payloadMethods = new Set(
-  Object.freeze(["PATCH", "POST", "PUT", "DELETE"])
+  Object.freeze(["PATCH", "POST", "PUT", "DELETE", "QUERY"])
 );
 export function isPayloadMethod(method = "GET"): boolean {
   return payloadMethods.has(method.toUpperCase());

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -158,6 +158,17 @@ describe("ofetch", () => {
     }
   });
 
+  it("stringifies query body automatically", async () => {
+    // RFC 10008 QUERY method is a payload method (like POST) — bodies should be
+    // JSON-stringified and default Content-Type/Accept headers should be set.
+    const { body, headers } = await $fetch(getURL("post"), {
+      method: "QUERY",
+      body: { num: 42 },
+    });
+    expect(body).to.deep.eq({ num: 42 });
+    expect(headers).to.include({ "content-type": "application/json" });
+    expect(headers).to.include({ accept: "application/json" });
+  });
   it("does not stringify body when content type != application/json", async () => {
     const message = '"Hallo von Pascal"';
     const { body } = await $fetch(getURL("echo"), {


### PR DESCRIPTION
## Summary

Treat the HTTP QUERY method (RFC 10008, recently accepted as a proposed standard) as a payload method, alongside PATCH/POST/PUT/DELETE. Without this change, passing a JS object as the body of a `QUERY` request results in `[object Object]` being sent to `fetch()` (or a `TypeError`).

Per #610, this PR is a one-line code change plus a regression test and a README update.

## Changes

- `src/utils.ts`: add `"QUERY"` to the `payloadMethods` set so `isPayloadMethod()` returns true for QUERY.
- `README.md`: update the lists of payload methods in the JSON Body and Retry sections to include QUERY (the current README was already inconsistent — the source includes DELETE while the README JSON Body section omits it).
- `test/index.test.ts`: add a regression test verifying that bodies on QUERY requests are JSON-stringified and the default `Content-Type: application/json` and `Accept: application/json` headers are set.

## Why QUERY is a payload method

QUERY is the IETF standardized answer to "how do I send a body for a query when the GET query string is too long". Like POST/PUT/PATCH, it carries a request body, so the same default-handling applies:

- auto-stringify JS objects to JSON,
- set `Content-Type: application/json` and `Accept: application/json` by default,
- disable the default retry (QUERY is not declared safe / idempotent in RFC 10008).

## Test plan

- [x] `pnpm vitest run` — 29/29 tests pass (28 existing + 1 new)
- [x] `pnpm lint` — clean (eslint + prettier)

Closes #610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `QUERY` requests now support JSON object bodies.
  * Object bodies are automatically serialized as JSON.
  * Default `Content-Type` and `Accept` headers are set to `application/json` for JSON `QUERY` requests.
  * `QUERY` requests are included in the default retry exclusions.

* **Documentation**
  * Updated documentation to describe JSON-header behavior and retry exclusions for `QUERY` requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->