### PR TITLE
fix: normalize errors thrown while reading the response body

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -36,7 +36,10 @@ const nullBodyResponses = new Set([101, 204, 205, 304]);
 export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
   const { fetch = globalThis.fetch } = globalOptions;
 
-  async function onError(context: FetchContext): Promise<FetchResponse<any>> {
+  async function onError(
+    context: FetchContext,
+    isTransportError = false
+  ): Promise<FetchResponse<any>> {
     // Is Abort
     // If it is an active abort, it will not retry automatically.
     // https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names
@@ -57,10 +60,10 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       // A failure while reading the body (aborted/timed out stream, network
       // error mid-stream) is a transport failure even though the response
       // headers already arrived, so retry eligibility must not be decided from
-      // the (successful) status code of that response. Parse failures are not
-      // retryable since replaying the request cannot make the payload valid.
-      const isTransportError =
-        !!context.error && context.error.name !== "SyntaxError";
+      // the (successful) status code of that response. Failures raised while
+      // parsing an already-read body are not transport errors: the request did
+      // succeed, and replaying it (possibly non-idempotent) cannot make the
+      // payload valid.
       const responseCode =
         (!isTransportError && context.response && context.response.status) ||
         500;
@@ -197,7 +200,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           context.options.onRequestError
         );
       }
-      return await onError(context);
+      return await onError(context, true);
     }
 
     const hasBody =
@@ -215,10 +218,16 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           : context.options.responseType) ||
         detectResponseType(context.response.headers.get("content-type") || "");
 
+      // Reading the body is a continuation of the transport (the stream can be
+      // aborted, time out or fail mid-way), while parsing it happens after the
+      // request already succeeded. They are tracked separately so only the
+      // former is eligible for a retry.
+      let isTransportError = true;
       try {
         switch (responseType) {
           case "json": {
             const data = await context.response.text();
+            isTransportError = false;
             if (data) {
               const parseFunction = context.options.parseResponse || JSON.parse;
               context.response._data = parseFunction(data);
@@ -235,9 +244,9 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           }
         }
       } catch (error) {
-        // Reading the body can fail on its own (aborted/timed out stream,
-        // network error mid-stream, invalid JSON), so normalize it like any
-        // other request error instead of leaking the raw rejection.
+        // Reading or parsing the body can fail on its own (aborted/timed out
+        // stream, network error mid-stream, invalid JSON), so normalize it like
+        // any other request error instead of leaking the raw rejection.
         // https://github.com/unjs/ofetch/issues/620
         context.error = error as Error;
         if (context.options.onRequestError) {
@@ -246,7 +255,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
             context.options.onRequestError
           );
         }
-        return await onError(context);
+        return await onError(context, isTransportError);
       }
     }
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -166,8 +166,6 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       }
     }
 
-    let abortTimeout: NodeJS.Timeout | undefined;
-
     if (context.options.timeout) {
       context.options.signal = context.options.signal
         ? AbortSignal.any([
@@ -191,10 +189,6 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         );
       }
       return await onError(context);
-    } finally {
-      if (abortTimeout) {
-        clearTimeout(abortTimeout);
-      }
     }
 
     const hasBody =
@@ -212,23 +206,38 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           : context.options.responseType) ||
         detectResponseType(context.response.headers.get("content-type") || "");
 
-      switch (responseType) {
-        case "json": {
-          const data = await context.response.text();
-          if (data) {
-            const parseFunction = context.options.parseResponse || JSON.parse;
-            context.response._data = parseFunction(data);
+      try {
+        switch (responseType) {
+          case "json": {
+            const data = await context.response.text();
+            if (data) {
+              const parseFunction = context.options.parseResponse || JSON.parse;
+              context.response._data = parseFunction(data);
+            }
+            break;
           }
-          break;
+          case "stream": {
+            context.response._data =
+              context.response.body || (context.response as any)._bodyInit; // (see refs above)
+            break;
+          }
+          default: {
+            context.response._data = await context.response[responseType]();
+          }
         }
-        case "stream": {
-          context.response._data =
-            context.response.body || (context.response as any)._bodyInit; // (see refs above)
-          break;
+      } catch (error) {
+        // Reading the body can fail on its own (aborted/timed out stream,
+        // network error mid-stream, invalid JSON), so normalize it like any
+        // other request error instead of leaking the raw rejection.
+        // https://github.com/unjs/ofetch/issues/620
+        context.error = error as Error;
+        if (context.options.onRequestError) {
+          await callHooks(
+            context as FetchContext & { error: Error },
+            context.options.onRequestError
+          );
         }
-        default: {
-          context.response._data = await context.response[responseType]();
-        }
+        return await onError(context);
       }
     }
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -54,7 +54,16 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         retries = isPayloadMethod(context.options.method) ? 0 : 1;
       }
 
-      const responseCode = (context.response && context.response.status) || 500;
+      // A failure while reading the body (aborted/timed out stream, network
+      // error mid-stream) is a transport failure even though the response
+      // headers already arrived, so retry eligibility must not be decided from
+      // the (successful) status code of that response. Parse failures are not
+      // retryable since replaying the request cannot make the payload valid.
+      const isTransportError =
+        !!context.error && context.error.name !== "SyntaxError";
+      const responseCode =
+        (!isTransportError && context.response && context.response.status) ||
+        500;
       if (
         retries > 0 &&
         (Array.isArray(context.options.retryStatusCodes)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -394,6 +394,24 @@ describe("ofetch", () => {
     expect(attempts).to.equal(2);
   });
 
+  it("does not retry when parseResponse throws", async () => {
+    // The body was read successfully, so the request did happen: replaying a
+    // possibly non-idempotent request cannot make the payload parseable.
+    let attempts = 0;
+    const error = await $fetch(getURL("ok"), {
+      retry: 1,
+      retryDelay: 0,
+      onRequest() {
+        attempts++;
+      },
+      parseResponse() {
+        throw new TypeError("bad payload");
+      },
+    }).catch((error_: any) => error_);
+    expect(attempts).to.equal(1);
+    expect(error.cause?.message).to.equal("bad payload");
+  });
+
   it("deep merges defaultOptions", async () => {
     const _customFetch = $fetch.create({
       query: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -62,6 +62,15 @@ describe("ofetch", () => {
             resolve(new HTTPError({ status: 408 }));
           }, 1000 * 5);
         });
+      })
+      .all("/timeout-body", (event) => {
+        // Responds with headers immediately, then keeps the body open forever.
+        event.res.headers.set("content-type", "application/json");
+        return new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"foo":'));
+          },
+        });
       });
 
     listener = await serve(app, { port: 0, hostname: "localhost" }).ready();
@@ -342,6 +351,18 @@ describe("ofetch", () => {
       expect(error.cause.name).to.equal("TimeoutError");
       expect(error.cause.code).to.equal(DOMException.TIMEOUT_ERR);
     });
+  });
+
+  it("aborting on timeout while the body is still streaming", async () => {
+    // https://github.com/unjs/ofetch/issues/620
+    const request = $fetch(getURL("timeout-body"), {
+      timeout: 100,
+      retry: 0,
+    }).catch((error: any) => error);
+    const hang = new Promise((resolve) => setTimeout(resolve, 1000, "hang"));
+    const result = await Promise.race([request, hang]);
+    expect(result).not.to.equal("hang");
+    expect((result as any).cause?.name).to.equal("TimeoutError");
   });
 
   it("deep merges defaultOptions", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -359,10 +359,39 @@ describe("ofetch", () => {
       timeout: 100,
       retry: 0,
     }).catch((error: any) => error);
-    const hang = new Promise((resolve) => setTimeout(resolve, 1000, "hang"));
-    const result = await Promise.race([request, hang]);
+    let hangTimer: ReturnType<typeof setTimeout> | undefined;
+    const hang = new Promise((resolve) => {
+      hangTimer = setTimeout(resolve, 1000, "hang");
+    });
+    const result = await Promise.race([request, hang]).finally(() => {
+      clearTimeout(hangTimer);
+    });
     expect(result).not.to.equal("hang");
     expect((result as any).cause?.name).to.equal("TimeoutError");
+  });
+
+  it("retries when the body read times out", async () => {
+    // https://github.com/unjs/ofetch/issues/620
+    // The response headers arrive successfully, so the retry decision must not
+    // be based on the (200) status of the response we failed to read.
+    let attempts = 0;
+    const request = $fetch(getURL("timeout-body"), {
+      timeout: 100,
+      retry: 1,
+      retryDelay: 0,
+      onRequest() {
+        attempts++;
+      },
+    }).catch((error: any) => error);
+    let hangTimer: ReturnType<typeof setTimeout> | undefined;
+    const hang = new Promise((resolve) => {
+      hangTimer = setTimeout(resolve, 2000, "hang");
+    });
+    const result = await Promise.race([request, hang]).finally(() => {
+      clearTimeout(hangTimer);
+    });
+    expect(result).not.to.equal("hang");
+    expect(attempts).to.equal(2);
   });
 
   it("deep merges defaultOptions", async () => {


### PR DESCRIPTION
Closes #620

### Problem

`timeout` is applied via `AbortSignal.timeout()` before the `fetch()` call, so on `main` it *does* already fire while the response body is still streaming (the v1 `setTimeout` + `AbortController` approach did not — that part of #620 was fixed by the `AbortSignal.timeout` refactor).

What's still broken is the **error that comes out**. Reading the body happens outside the `try`/`catch` that wraps `fetch()`, so any failure there rejects with the raw underlying error:

```
DOMException [TimeoutError]: The operation was aborted due to timeout
```

instead of the normalized `FetchError`. Practical consequences:

- `error.request`, `error.response`, `error.options` and `error.data` are all missing
- the `onRequestError` hook is never called
- the message has no `[GET] "<url>"` prefix, unlike every other failure mode

A timeout that happens 1 ms before the headers arrive and one that happens 1 ms after produce two very different error shapes today. The same applies to a connection reset mid-stream, or `JSON.parse` throwing on a truncated payload.

### Change

- `src/fetch.ts`: wrap the response-body reading `switch` in `try`/`catch` and route failures through the existing `onRequestError` + `onError()` path, so they are normalized exactly like fetch-phase errors (retry handling included).
- `src/fetch.ts`: drop the leftover `abortTimeout` variable and its `finally { clearTimeout(...) }` block — it was never assigned since the switch to `AbortSignal.timeout()`, so it was dead code.
- `test/index.test.ts`: add a `/timeout-body` route that flushes headers and then keeps the body open forever, plus a regression test asserting the request rejects (rather than hanging) with `cause.name === "TimeoutError"`.

Without the `src` change the new test fails on `cause` being `undefined`, since the raw `DOMException` has no `cause`.

### Validation

```
vitest run   → 29 passed (29)
eslint .     → clean
prettier -c  → clean
tsc --noEmit → clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for slow, incomplete, or streaming response bodies.
  * Requests that time out while reading responses now report a consistent `TimeoutError`.
  * Response-body failures now follow standard error and retry handling.
  * Transient body-read failures can be retried, while invalid JSON errors are not.
  * Timed-out streaming responses now abort cleanly without hanging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->