### PR TITLE
fix: treat null as JSON-serializable (isJSONSerializable(null) throws)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function isJSONSerializable(value: any): boolean {
     return false;
   }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (value === null || t === "string" || t === "number" || t === "boolean") {
     return true;
   }
   if (t !== "object") {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { isJSONSerializable } from "../src/utils.ts";
+
+describe("isJSONSerializable", () => {
+  it("treats null as serializable and does not throw", () => {
+    // `null` is valid JSON (`JSON.stringify(null) === "null"`).
+    // Previously this threw `Cannot read properties of null (reading 'buffer')`.
+    /* eslint-disable unicorn/no-null -- exercising null is the point of this test */
+    expect(() => isJSONSerializable(null)).not.toThrow();
+    expect(isJSONSerializable(null)).toBe(true);
+    /* eslint-enable unicorn/no-null */
+  });
+
+  it("handles primitives", () => {
+    expect(isJSONSerializable("hello")).toBe(true);
+    expect(isJSONSerializable(42)).toBe(true);
+    expect(isJSONSerializable(true)).toBe(true);
+    expect(isJSONSerializable(undefined)).toBe(false);
+    expect(isJSONSerializable(10n)).toBe(false);
+    expect(isJSONSerializable(() => {})).toBe(false);
+  });
+
+  it("handles plain objects and arrays", () => {
+    expect(isJSONSerializable({ a: 1 })).toBe(true);
+    expect(isJSONSerializable([1, 2, 3])).toBe(true);
+    expect(isJSONSerializable({ toJSON: () => ({}) })).toBe(true);
+  });
+
+  it("rejects streams, FormData and URLSearchParams", () => {
+    expect(isJSONSerializable(new FormData())).toBe(false);
+    expect(isJSONSerializable(new URLSearchParams())).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #571.

`isJSONSerializable(null)` currently **throws** `Cannot read properties of null (reading 'buffer')`:

- `t === null` is dead code — `typeof` always returns a string, never `null`.
- So `null` isn't caught there, falls past the `t !== "object"` guard, and reaches `value.buffer`, which throws.

`null` is valid JSON (`JSON.stringify(null) === "null"`), so it should return `true`. This replaces the dead `t === null` check with `value === null`, catching `null` before the `.buffer` access.

Also adds `test/utils.test.ts` — the util had no direct unit test — covering `null`, primitives, plain objects/arrays, and `FormData`/`URLSearchParams`. All existing tests still pass; lint clean.

---
_Disclosure: this change was written with AI assistance. I've reviewed, tested, and understand it, and I'll maintain it._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON serialization checks so `null` is recognized as a supported value without causing errors.

* **Tests**
  * Added coverage for primitives, objects, arrays, custom serialization, form-related types, URL search parameters, and unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->